### PR TITLE
Rename GH_KEYCHAIN_SERVICE to GH_TOKEN_NAME with short names

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,8 +102,8 @@ ALLOWED_AWS_PROFILES="dev staging"
 # default AWS profile
 DEFAULT_AWS_PROFILE="dev"
 
-# token name registered via `jailrun token`
-GH_KEYCHAIN_SERVICE="github:classic"
+# short token name — internally expanded to jailrun:github:<name>
+GH_TOKEN_NAME="classic"
 ```
 
 Binary paths are resolved automatically via `command -v` with PATH cleaning

--- a/docs/github-pat-setup.md
+++ b/docs/github-pat-setup.md
@@ -112,10 +112,16 @@ Token names are arbitrary. Recommended naming by Organization:
 
 ### Switch Active Token
 
-Set the active token in `~/.config/jailrun/config`:
+Set the active token in `~/.config/jailrun/config` (short name only):
 
 ```bash
-GH_KEYCHAIN_SERVICE="github:fine-grained-myorg"  # or github:classic
+GH_TOKEN_NAME="fine-grained-myorg"  # or classic
+```
+
+Override at runtime:
+
+```bash
+GH_TOKEN_NAME=fine-grained-myorg jailrun claude
 ```
 
 ### List Registered Tokens

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -3,7 +3,7 @@
 # sourced by credential-guard.sh
 #
 # exports: CONFIG_DIR, CONFIG_FILE, _WRAPPER_NAME,
-#          ALLOWED_AWS_PROFILES, DEFAULT_AWS_PROFILE, GH_KEYCHAIN_SERVICE,
+#          ALLOWED_AWS_PROFILES, DEFAULT_AWS_PROFILE, GH_TOKEN_NAME,
 #          _DEFAULT_REGION, SANDBOX_EXTRA_*
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/jailrun"
@@ -18,10 +18,13 @@ if [ ! -f "$CONFIG_FILE" ] && [ -f "$_OLD_CONFIG_DIR/config" ]; then
   echo "[$_WRAPPER_NAME] config migrated: $_OLD_CONFIG_DIR -> $CONFIG_DIR" >&2
 fi
 
+# save caller's env override before defaults overwrite it
+_GH_TOKEN_NAME_OVERRIDE="${GH_TOKEN_NAME:-}"
+
 # defaults
 ALLOWED_AWS_PROFILES=""
 DEFAULT_AWS_PROFILE=""
-GH_KEYCHAIN_SERVICE="github:classic"
+GH_TOKEN_NAME="classic"
 _DEFAULT_REGION="ap-northeast-1"
 
 SANDBOX_EXTRA_DENY_READ=""
@@ -32,6 +35,16 @@ SANDBOX_PASSTHROUGH_ENV="${SANDBOX_PASSTHROUGH_ENV:-}"
 # load or generate config
 if [ -f "$CONFIG_FILE" ]; then
   . "$CONFIG_FILE"
+  # migrate legacy GH_KEYCHAIN_SERVICE -> GH_TOKEN_NAME
+  # only apply if config has GH_KEYCHAIN_SERVICE but NOT GH_TOKEN_NAME
+  if [ -n "${GH_KEYCHAIN_SERVICE:-}" ] && ! grep -qE '(^|export[[:space:]]+)GH_TOKEN_NAME=' "$CONFIG_FILE" 2>/dev/null; then
+    # strip "github:" prefix if present (e.g. "github:classic" -> "classic")
+    case "$GH_KEYCHAIN_SERVICE" in
+      github:*) GH_TOKEN_NAME="${GH_KEYCHAIN_SERVICE#github:}" ;;
+      *)        GH_TOKEN_NAME="$GH_KEYCHAIN_SERVICE" ;;
+    esac
+    echo "[$_WRAPPER_NAME] WARN: GH_KEYCHAIN_SERVICE is deprecated, use GH_TOKEN_NAME=\"$GH_TOKEN_NAME\" instead" >&2
+  fi
 else
   echo "[$_WRAPPER_NAME] config not found: $CONFIG_FILE" >&2
   echo "[$_WRAPPER_NAME] generating initial config..." >&2
@@ -48,9 +61,9 @@ ALLOWED_AWS_PROFILES="default"
 DEFAULT_AWS_PROFILE="default"
 
 # --- GitHub ---
-# token name registered via `jailrun token`
-# github:fine-grained-myorg / github:classic
-GH_KEYCHAIN_SERVICE="github:classic"
+# short token name — internally expanded to jailrun:github:<name>
+# e.g. classic / fine-grained-myorg
+GH_TOKEN_NAME="classic"
 
 # --- sandbox customization ---
 # additional read-deny paths (space-separated)
@@ -74,3 +87,7 @@ CONF
 fi
 
 DEFAULT_AWS_PROFILE="${AWS_PROFILE:-$DEFAULT_AWS_PROFILE}"
+
+# runtime override: GH_TOKEN_NAME=<name> jailrun claude
+GH_TOKEN_NAME="${_GH_TOKEN_NAME_OVERRIDE:-$GH_TOKEN_NAME}"
+unset _GH_TOKEN_NAME_OVERRIDE

--- a/lib/credentials.sh
+++ b/lib/credentials.sh
@@ -3,7 +3,7 @@
 # sourced by credential-guard.sh
 #
 # requires: $_WRAPPER_NAME, $DEFAULT_AWS_PROFILE, $ALLOWED_AWS_PROFILES,
-#           $_DEFAULT_REGION, $GH_KEYCHAIN_SERVICE, $JAILRUN_LIB
+#           $_DEFAULT_REGION, $GH_TOKEN_NAME, $JAILRUN_LIB
 # exports: $_tmpdir, $_aws_config, $_aws_creds, $_gh_token, $_gh_token_source
 
 _tmpdir=$(mktemp -d)

--- a/lib/platform/keychain-darwin.sh
+++ b/lib/platform/keychain-darwin.sh
@@ -2,13 +2,13 @@
 # Retrieve token from macOS Keychain
 # Sourced by credential-guard.sh
 #
-# Requires: $GH_KEYCHAIN_SERVICE to be set
+# Requires: $GH_TOKEN_NAME to be set (short name, e.g. "classic")
 # Outputs: $_gh_token, $_gh_token_source
 
 _get_gh_token() {
   _gh_token=""
   _gh_token_source=""
-  _gh_token=$(security find-generic-password -s "jailrun:$GH_KEYCHAIN_SERVICE" -a "$USER" -w 2>/dev/null) || true
+  _gh_token=$(security find-generic-password -s "jailrun:github:$GH_TOKEN_NAME" -a "$USER" -w 2>/dev/null) || true
   [ -n "$_gh_token" ] && _gh_token_source="Keychain"
   return 0
 }

--- a/lib/platform/keychain-linux.sh
+++ b/lib/platform/keychain-linux.sh
@@ -2,14 +2,14 @@
 # Retrieve token from Linux GNOME Keyring
 # Sourced by credential-guard.sh
 #
-# Requires: $GH_KEYCHAIN_SERVICE, $_WRAPPER_NAME to be set
+# Requires: $GH_TOKEN_NAME, $_WRAPPER_NAME to be set (short name, e.g. "classic")
 # Outputs: $_gh_token, $_gh_token_source
 
 _get_gh_token() {
   _gh_token=""
   _gh_token_source=""
   if command -v secret-tool >/dev/null 2>&1; then
-    _gh_token=$(secret-tool lookup service "jailrun:$GH_KEYCHAIN_SERVICE" account "$USER" 2>/dev/null) || true
+    _gh_token=$(secret-tool lookup service "jailrun:github:$GH_TOKEN_NAME" account "$USER" 2>/dev/null) || true
     [ -n "$_gh_token" ] && _gh_token_source="GNOME Keyring"
   else
     echo "[$_WRAPPER_NAME] WARN: secret-tool not installed (sudo apt install libsecret-tools gnome-keyring)" >&2

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -24,7 +24,7 @@ teardown() {
   [ -f "$TEST_CONFIG_DIR/jailrun/config" ]
   # config contains expected variables
   grep -q "ALLOWED_AWS_PROFILES" "$TEST_CONFIG_DIR/jailrun/config"
-  grep -q "GH_KEYCHAIN_SERVICE" "$TEST_CONFIG_DIR/jailrun/config"
+  grep -q "GH_TOKEN_NAME" "$TEST_CONFIG_DIR/jailrun/config"
 }
 
 @test "config.sh loads existing config" {
@@ -32,7 +32,7 @@ teardown() {
   cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
 ALLOWED_AWS_PROFILES="testprofile"
 DEFAULT_AWS_PROFILE="testprofile"
-GH_KEYCHAIN_SERVICE="github:test"
+GH_TOKEN_NAME="test"
 EOF
 
   run sh -c '
@@ -41,12 +41,12 @@ EOF
     . "'"$JAILRUN_LIB"'/config.sh"
     echo "profiles=$ALLOWED_AWS_PROFILES"
     echo "default=$DEFAULT_AWS_PROFILE"
-    echo "gh=$GH_KEYCHAIN_SERVICE"
+    echo "gh=$GH_TOKEN_NAME"
   '
   [ "$status" -eq 0 ]
   [[ "$output" == *"profiles=testprofile"* ]]
   [[ "$output" == *"default=testprofile"* ]]
-  [[ "$output" == *"gh=github:test"* ]]
+  [[ "$output" == *"gh=test"* ]]
 }
 
 @test "config.sh has no *_BIN variables in generated config" {
@@ -60,6 +60,93 @@ EOF
     run grep -c '_BIN=' "$TEST_CONFIG_DIR/jailrun/config"
     [ "$output" = "0" ]
   fi
+}
+
+@test "config.sh migrates legacy GH_KEYCHAIN_SERVICE with github: prefix" {
+  mkdir -p "$TEST_CONFIG_DIR/jailrun"
+  cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
+GH_KEYCHAIN_SERVICE="github:fine-grained-myorg"
+EOF
+
+  run sh -c '
+    export XDG_CONFIG_HOME="'"$TEST_CONFIG_DIR"'"
+    export WRAPPER_NAME=claude
+    . "'"$JAILRUN_LIB"'/config.sh"
+    echo "gh=$GH_TOKEN_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh=fine-grained-myorg"* ]]
+  [[ "$output" == *"GH_KEYCHAIN_SERVICE is deprecated"* ]]
+}
+
+@test "config.sh migrates legacy GH_KEYCHAIN_SERVICE without github: prefix" {
+  mkdir -p "$TEST_CONFIG_DIR/jailrun"
+  cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
+GH_KEYCHAIN_SERVICE="custom-token"
+EOF
+
+  run sh -c '
+    export XDG_CONFIG_HOME="'"$TEST_CONFIG_DIR"'"
+    export WRAPPER_NAME=claude
+    . "'"$JAILRUN_LIB"'/config.sh"
+    echo "gh=$GH_TOKEN_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh=custom-token"* ]]
+}
+
+@test "config.sh GH_TOKEN_NAME takes precedence over legacy GH_KEYCHAIN_SERVICE" {
+  mkdir -p "$TEST_CONFIG_DIR/jailrun"
+  cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
+GH_TOKEN_NAME="classic"
+GH_KEYCHAIN_SERVICE="github:work"
+EOF
+
+  run sh -c '
+    export XDG_CONFIG_HOME="'"$TEST_CONFIG_DIR"'"
+    export WRAPPER_NAME=claude
+    . "'"$JAILRUN_LIB"'/config.sh"
+    echo "gh=$GH_TOKEN_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh=classic"* ]]
+  # should NOT show deprecation warning when GH_TOKEN_NAME is explicitly set
+  [[ "$output" != *"deprecated"* ]]
+}
+
+@test "config.sh GH_TOKEN_NAME with export syntax takes precedence over legacy" {
+  mkdir -p "$TEST_CONFIG_DIR/jailrun"
+  cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
+export GH_TOKEN_NAME="classic"
+GH_KEYCHAIN_SERVICE="github:work"
+EOF
+
+  run sh -c '
+    export XDG_CONFIG_HOME="'"$TEST_CONFIG_DIR"'"
+    export WRAPPER_NAME=claude
+    . "'"$JAILRUN_LIB"'/config.sh"
+    echo "gh=$GH_TOKEN_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh=classic"* ]]
+  [[ "$output" != *"deprecated"* ]]
+}
+
+@test "config.sh GH_TOKEN_NAME env override takes precedence" {
+  mkdir -p "$TEST_CONFIG_DIR/jailrun"
+  cat > "$TEST_CONFIG_DIR/jailrun/config" <<'EOF'
+GH_TOKEN_NAME="from-config"
+EOF
+
+  run sh -c '
+    export XDG_CONFIG_HOME="'"$TEST_CONFIG_DIR"'"
+    export WRAPPER_NAME=claude
+    export GH_TOKEN_NAME="from-env"
+    . "'"$JAILRUN_LIB"'/config.sh"
+    echo "gh=$GH_TOKEN_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh=from-env"* ]]
 }
 
 @test "config.sh migrates from old security-wrapper dir" {

--- a/tests/passthrough_env.bats
+++ b/tests/passthrough_env.bats
@@ -10,7 +10,7 @@ setup() {
   cat > "$TEST_CONFIG_DIR/jailrun/config" <<CONF
 ALLOWED_AWS_PROFILES=""
 DEFAULT_AWS_PROFILE=""
-GH_KEYCHAIN_SERVICE="github:classic"
+GH_TOKEN_NAME="classic"
 CONF
 }
 

--- a/tests/sandbox_profile.bats
+++ b/tests/sandbox_profile.bats
@@ -14,7 +14,7 @@ load helpers
     cat > "$XDG_CONFIG_HOME/jailrun/config" <<CONF
 ALLOWED_AWS_PROFILES=""
 DEFAULT_AWS_PROFILE=""
-GH_KEYCHAIN_SERVICE="github:classic"
+GH_TOKEN_NAME="classic"
 CONF
     . "$JAILRUN_LIB/config.sh"
     . "$JAILRUN_LIB/credentials.sh"
@@ -47,7 +47,7 @@ CONF
     cat > "$XDG_CONFIG_HOME/jailrun/config" <<CONF
 ALLOWED_AWS_PROFILES=""
 DEFAULT_AWS_PROFILE=""
-GH_KEYCHAIN_SERVICE="github:classic"
+GH_TOKEN_NAME="classic"
 CONF
     . "$JAILRUN_LIB/config.sh"
     . "$JAILRUN_LIB/credentials.sh"


### PR DESCRIPTION
## Summary
- Rename config variable `GH_KEYCHAIN_SERVICE` to `GH_TOKEN_NAME`
- Use short names only (e.g. `classic` instead of `github:classic`)
- Internal expansion to `jailrun:github:<name>` for keychain lookup
- Support runtime override via env var: `GH_TOKEN_NAME=fine-grained-myorg jailrun claude`
- Backward-compatible migration for legacy `GH_KEYCHAIN_SERVICE` configs with deprecation warning

## Files changed
- `lib/config.sh` — rename variable, add migration logic, env override
- `lib/credentials.sh` — update requires comment
- `lib/platform/keychain-darwin.sh` — expand short name to `jailrun:github:<name>`
- `lib/platform/keychain-linux.sh` — expand short name to `jailrun:github:<name>`
- `docs/README.md` — update config example
- `docs/github-pat-setup.md` — update config example, add runtime override doc
- `tests/config.bats` — add migration and env override tests
- `tests/sandbox_profile.bats` — update config fixture
- `tests/passthrough_env.bats` — update config fixture

Closes #3