### PR TITLE
サイクル v0.2.0

### DIFF
--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -1,7 +1,7 @@
 # AI-DLC プロジェクト設定
 # 生成日: 2026-03-28
 
-starter_kit_version = "2.0.2"
+starter_kit_version = "2.3.0"
 
 [project]
 name = "jailrun"
@@ -35,16 +35,15 @@ validate_user_input = true
 use_env_for_secrets = true
 
 [rules.git]
+ai_author = "Claude <noreply@anthropic.com>"
 # Git運用ルール
 commit_on_unit_complete = true
 commit_on_phase_complete = true
-
-[rules.commit]
-# コミット設定（v1.9.1で追加）
-# ai_author: Co-Authored-By に使用するAI著者情報
-# - 形式: "ツール名 <email>"（推奨）または任意の文字列
-# - デフォルト: "Claude <noreply@anthropic.com>"
-ai_author = "Claude <noreply@anthropic.com>"
+branch_mode = "ask"
+unit_branch_enabled = false
+squash_enabled = false
+merge_method = "ask"
+ai_author_auto_detect = true
 
 [rules.documentation]
 language = "日本語"
@@ -64,7 +63,8 @@ tools = ["codex"]
 # exclude_patterns: レビュー対象から除外するファイルパターン（配列）
 # - デフォルトパターン(.env*, *.key, *.pem, credentials.*, *secret*)は常に適用
 # - ここに追加のパターンを指定可能
-# exclude_patterns = ["*.p12", "config/secrets/**"]
+exclude_patterns = []
+codex_bot_account = "chatgpt-codex-connector[bot]"
 
 [rules.worktree]
 # git worktree設定
@@ -73,20 +73,13 @@ tools = ["codex"]
 # - false: 提案しない（デフォルト）
 enabled = false
 
-[rules.history]
-# 履歴記録設定
-# level: "detailed" | "standard" | "minimal"
-# - detailed: ステップ完了時に記録 + 修正差分も記録
-# - standard: ステップ完了時に記録（デフォルト）
-# - minimal: Unit完了時にまとめて記録
-level = "standard"
-
 [rules.linting]
 # markdownlint設定（v1.8.0で追加）
 # markdown_lint: true | false
 # - true: markdownlint を実行する
 # - false: markdownlint をスキップする（デフォルト）
-markdown_lint = false
+enabled = false
+command = "npx markdownlint-cli2"
 
 [rules.feedback]
 # フィードバック送信機能設定（v1.13.3で追加）
@@ -117,3 +110,33 @@ mode = "semi_auto"
 # - git-only: ローカルファイルのみ（Issueへの記録を禁止）
 # - issue-only: GitHub Issueのみ（ローカルファイルへの記録を禁止）（デフォルト）
 mode = "issue-only"
+
+[rules.release]
+# リリース設定（v2.1.6で追加）
+# changelog: true | false - CHANGELOG自動更新（デフォルト: false）
+# version_tag: true | false - gitタグ作成（デフォルト: false）
+changelog = false
+version_tag = false
+
+[rules.depth_level]
+# 成果物詳細度設定（v1.19.0で追加）
+# level: "minimal" | "standard" | "comprehensive"
+level = "standard"
+history_level = ""
+
+[rules.construction]
+# Construction Phase設定（v2.0.0で追加）
+# max_retry: Self-Healingループの最大リトライ回数（デフォルト: 3）
+max_retry = 3
+
+[rules.cycle]
+# サイクル設定（v2.1.6で追加）
+# mode: "default"
+# git_tracked: true | false - cyclesをgit管理するか（デフォルト: true）
+mode = "default"
+git_tracked = true
+
+[rules.version_check]
+# バージョンチェック設定（v2.1.4でupgrade_checkからリネーム）
+# enabled: true | false（デフォルト: true）
+enabled = true

--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -39,7 +39,7 @@ ai_author = "Claude <noreply@anthropic.com>"
 # Git運用ルール
 commit_on_unit_complete = true
 commit_on_phase_complete = true
-branch_mode = "ask"
+branch_mode = "branch"
 unit_branch_enabled = false
 squash_enabled = false
 merge_method = "ask"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,10 @@
       "Skill(reviewing-operations-premerge)",
       "Skill(write-history)"
     ],
+    "deny": [
+      "Edit(.claude/plugins/**)",
+      "Write(.claude/plugins/**)"
+    ],
     "ask": [
       "Bash(git push*--force *)",
       "Bash(git push*--force-with-lease *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,20 @@
       "Skill(reviewing-code)",
       "Skill(reviewing-inception)",
       "Skill(reviewing-security)",
-      "Skill(squash-unit)"
+      "Skill(squash-unit)",
+      "Bash(skills/*/scripts/*)",
+      "Skill(aidlc-feedback)",
+      "Skill(aidlc-migrate)",
+      "Skill(reviewing-inception-intent)",
+      "Skill(reviewing-inception-stories)",
+      "Skill(reviewing-inception-units)",
+      "Skill(reviewing-construction-plan)",
+      "Skill(reviewing-construction-design)",
+      "Skill(reviewing-construction-code)",
+      "Skill(reviewing-construction-integration)",
+      "Skill(reviewing-operations-deploy)",
+      "Skill(reviewing-operations-premerge)",
+      "Skill(write-history)"
     ],
     "ask": [
       "Bash(git push*--force *)",

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,17 +140,19 @@ These directories are blocked at kernel level:
 
 Additional paths can be added via `SANDBOX_EXTRA_DENY_READ` in config.
 
-### Keychain / Keyring Blocking
+### Keychain / Keyring Access
 
-The sandbox blocks direct access to OS credential stores:
+The sandbox treats OS credential stores differently by platform:
 
 | Platform | Mechanism |
 |----------|-----------|
-| macOS | Seatbelt denies `mach-lookup` for `com.apple.SecurityServer` |
+| macOS | Seatbelt keeps `com.apple.SecurityServer` reachable and permits writes under `~/Library/Keychains` |
 | Linux | D-Bus session bus socket made inaccessible via `InaccessiblePaths` |
 
-Tokens are injected as env vars before sandbox exec, so keychain access is
-not needed — and now not possible — from within the sandbox.
+On macOS, this is required for native TLS trust evaluation and for sandboxed
+apps that refresh their own auth state through Keychain-backed storage.
+Secrets are still protected by read-deny rules on sensitive files and by
+injecting scoped credentials via environment variables before sandbox exec.
 
 ### Environment Variable Passthrough
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -273,10 +273,11 @@ Seatbelt deny events during execution and displays them on stderr at exit.
 AGENT_SANDBOX_DEBUG=1 jailrun claude
 ```
 
-Deny events are logged to `$TMPDIR/jailrun-seatbelt-<PID>.log` (PID-based
-filename prevents conflicts during parallel runs). On exit, if the log file
-is non-empty, its contents are printed between `=== Seatbelt deny log ===`
-markers on stderr.
+Deny events are logged to `jailrun-seatbelt-<PID>.log` inside jailrun's
+temporary working directory (created via `mktemp -d`). The PID-based
+filename prevents conflicts during parallel runs. On exit, if the log
+file is non-empty, its contents are printed between
+`=== Seatbelt deny log ===` markers on stderr.
 
 This helps identify which file-system operations the sandbox blocked,
 making it easier to diagnose issues like token refresh failures or

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,26 @@ apps that refresh their own auth state through Keychain-backed storage.
 Secrets are still protected by read-deny rules on sensitive files and by
 injecting scoped credentials via environment variables before sandbox exec.
 
+### Write Allowances
+
+The sandbox permits writes to specific paths required by Claude Code's
+lock and config update mechanisms:
+
+| Path / Pattern | Platform | Purpose |
+|----------------|----------|---------|
+| `~/.claude.lock` | macOS + Linux | Lock directory for `~/.claude` (proper-lockfile) |
+| `~/.claude.json.lock` | macOS + Linux | Lock directory for `~/.claude.json` (proper-lockfile) |
+| `~/.claude.json.tmp.*` | macOS only | Atomic write temp file (Seatbelt regex) |
+
+Lockfile paths are directories created by proper-lockfile next to their
+target files. Both macOS (Seatbelt `subpath`) and Linux (systemd
+`ReadWritePaths`) grant write access to these paths.
+
+The atomic write regex pattern (`~/.claude.json.tmp.*`) is consumed only
+by the macOS Seatbelt profile. Linux's systemd backend does not support
+regex-based write permissions; target files are covered implicitly when
+the working directory includes `$HOME`.
+
 ### Environment Variable Passthrough
 
 By default, the sandbox strips sensitive environment variables. To pass custom
@@ -239,6 +259,27 @@ cat ~/.aws/config
 ## Troubleshooting
 
 > For common issues, see the [main README](../README.md#troubleshooting).
+
+### Seatbelt Deny Log (macOS)
+
+When `AGENT_SANDBOX_DEBUG=1` is set, jailrun automatically collects
+Seatbelt deny events during execution and displays them on stderr at exit.
+
+```bash
+AGENT_SANDBOX_DEBUG=1 jailrun claude
+```
+
+Deny events are logged to `$TMPDIR/jailrun-seatbelt-<PID>.log` (PID-based
+filename prevents conflicts during parallel runs). On exit, if the log file
+is non-empty, its contents are printed between `=== Seatbelt deny log ===`
+markers on stderr.
+
+This helps identify which file-system operations the sandbox blocked,
+making it easier to diagnose issues like token refresh failures or
+unexpected permission errors.
+
+> **Note**: This feature is macOS-only. Linux does not currently support
+> deny event logging.
 
 ### Advanced: Finding Blocked Write Paths
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,22 +157,25 @@ injecting scoped credentials via environment variables before sandbox exec.
 ### Write Allowances
 
 The sandbox permits writes to specific paths required by Claude Code's
-lock and config update mechanisms:
+lock mechanism. Direct config file updates (`~/.claude.json`) are fully
+covered only on macOS:
 
 | Path / Pattern | Platform | Purpose |
 |----------------|----------|---------|
 | `~/.claude.lock` | macOS + Linux | Lock directory for `~/.claude` (proper-lockfile) |
 | `~/.claude.json.lock` | macOS + Linux | Lock directory for `~/.claude.json` (proper-lockfile) |
-| `~/.claude.json.tmp.*` | macOS only | Atomic write temp file (Seatbelt regex) |
+| `~/.claude.json` | macOS only | Config file (Seatbelt `literal` permission) |
+| `~/.claude.json.tmp.*` | macOS only | Atomic write temp file (Seatbelt `regex` permission) |
 
 Lockfile paths are directories created by proper-lockfile next to their
 target files. Both macOS (Seatbelt `subpath`) and Linux (systemd
 `ReadWritePaths`) grant write access to these paths.
 
-The atomic write regex pattern (`~/.claude.json.tmp.*`) is consumed only
-by the macOS Seatbelt profile. Linux's systemd backend does not support
-regex-based write permissions; target files are covered implicitly when
-the working directory includes `$HOME`.
+The single-file write (`~/.claude.json`) and the atomic write regex
+pattern (`~/.claude.json.tmp.*`) are consumed only by the macOS Seatbelt
+profile. Linux's systemd backend does not support single-file or
+regex-based write permissions; these files are writable on Linux only
+when the working directory happens to be under `$HOME`.
 
 ### Environment Variable Passthrough
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,8 @@ The single-file write (`~/.claude.json`) and the atomic write regex
 pattern (`~/.claude.json.tmp.*`) are consumed only by the macOS Seatbelt
 profile. Linux's systemd backend does not support single-file or
 regex-based write permissions; these files are writable on Linux only
-when the working directory happens to be under `$HOME`.
+when a writable path that contains them is explicitly granted (e.g.,
+`$_cwd` is `$HOME` itself, or via `SANDBOX_EXTRA_ALLOW_WRITE`).
 
 ### Environment Variable Passthrough
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,9 +113,9 @@ Default blocked paths (kernel-enforced):
 - `~/.gnupg` — GPG private keys
 - `~/.ssh` — SSH private keys
 
-### Keychain Blocking
+### Keychain / Keyring Handling
 
 | Platform | Mechanism |
 |----------|-----------|
-| macOS | Seatbelt denies `mach-lookup` for `com.apple.SecurityServer` |
+| macOS | Seatbelt allows `mach-lookup` for `com.apple.SecurityServer` and permits writes under `~/Library/Keychains` |
 | Linux | D-Bus session bus socket made inaccessible |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,10 @@ jailrun <agent> [args...]
   │    │         ├─ lib/platform/git-worktree.sh     Git worktree detection
   │    │         └─ lib/proxy.py           HTTPS CONNECT proxy (optional)
   │    │
-  │    └─ exec <agent-binary> [args...]   Sandboxed execution
+  │    ├─ _start_deny_log()          Deny log collection (DEBUG mode, Darwin only)
+  │    ├─ exec <agent-binary> [args...]   Sandboxed execution
+  │    ├─ _stop_deny_log()           Stop deny log collection (DEBUG mode)
+  │    └─ display deny log → stderr  Show collected deny events (DEBUG mode)
   │
   ├─ lib/token.sh             Token management (add/rotate/delete/list)
   └─ lib/ruleset.sh           GitHub repository ruleset management
@@ -53,7 +56,19 @@ jailrun <agent> [args...]
 | Env-spec generation | Generate SET/UNSET directives for credential isolation |
 | Exec script | Generate exec.sh with env setup + sandbox command |
 | Proxy management | Start/stop HTTPS CONNECT proxy if enabled |
-| Main entry point | Orchestrate sandbox setup, proxy, and exec |
+| Deny log hooks | Platform-specific deny event collection (Darwin: log stream, Linux: no-op) |
+| Main entry point | Orchestrate sandbox setup, proxy, deny log, and exec |
+
+#### Write Path Composition
+
+The allow-write path list is composed of several categories with different
+platform consumption models:
+
+| Write allowance type | Darwin (Seatbelt) | Linux (systemd) |
+|----------------------|-------------------|-----------------|
+| Lock paths (`_SANDBOX_ALLOW_WRITE_LOCK_PATHS`) | `subpath` permission | `ReadWritePaths` |
+| Single-file writes (`_SANDBOX_ALLOW_WRITE_FILES`) | `literal` permission | Not consumed |
+| Regex patterns (`_SANDBOX_ALLOW_WRITE_REGEXES`) | `regex` permission | Not consumed (no regex support) |
 
 ### Double-Sandbox Prevention
 
@@ -65,6 +80,18 @@ When an agent calls another agent (e.g., Claude → Codex via shim), the `_CREDE
 |----------|---------|-----------|
 | macOS | sandbox-darwin.sh | Seatbelt (sandbox-exec) with .sb profile |
 | Linux | sandbox-linux-systemd.sh | systemd-run with security properties |
+
+### Deny Log Architecture
+
+Deny event logging follows an Optional Hook pattern. The orchestrator
+(`sandbox.sh`) manages the lifecycle, while platform backends provide
+the actual implementation or a no-op stub:
+
+| Layer | Responsibility |
+|-------|---------------|
+| sandbox.sh (orchestrator) | Start/stop hooks in DEBUG mode, EXIT trap cleanup, stderr display at exit |
+| sandbox-darwin.sh (backend) | `_start_deny_log()`: start `log stream` with Seatbelt predicate, `_stop_deny_log()`: kill process. Warns on stderr if `log stream` fails to start |
+| sandbox-linux.sh (backend) | No-op (future extension point) |
 
 ### Proxy (Optional)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,12 +34,11 @@ jailrun <agent> [args...]
   │    │         ├─ lib/platform/sandbox-linux.sh    Linux systemd-run dispatch
   │    │         │    └─ lib/platform/sandbox-linux-systemd.sh   systemd property generation
   │    │         ├─ lib/platform/git-worktree.sh     Git worktree detection
-  │    │         └─ lib/proxy.py           HTTPS CONNECT proxy (optional)
-  │    │
-  │    ├─ _start_deny_log()          Deny log collection (DEBUG mode, Darwin only)
-  │    ├─ exec <agent-binary> [args...]   Sandboxed execution
-  │    ├─ _stop_deny_log()           Stop deny log collection (DEBUG mode)
-  │    └─ display deny log → stderr  Show collected deny events (DEBUG mode)
+  │    │         ├─ lib/proxy.py           HTTPS CONNECT proxy (optional)
+  │    │         ├─ _start_deny_log()      Deny log collection (DEBUG, Darwin only)
+  │    │         ├─ exec <agent-binary>    Sandboxed execution
+  │    │         ├─ _stop_deny_log()       Stop deny log (DEBUG)
+  │    │         └─ display deny log       Show deny events on stderr (DEBUG)
   │
   ├─ lib/token.sh             Token management (add/rotate/delete/list)
   └─ lib/ruleset.sh           GitHub repository ruleset management

--- a/lib/platform/sandbox-darwin.sh
+++ b/lib/platform/sandbox-darwin.sh
@@ -104,3 +104,29 @@ _setup_sandbox() {
 _build_sandbox_exec() {
   printf 'exec %s "$@"\n' "$_sandbox_cmd"
 }
+
+# Start Seatbelt deny event collection via log stream (background).
+# Sets _DENY_LOG_PID and _DENY_LOG_FILE on success.
+_start_deny_log() {
+  _DENY_LOG_FILE="$_tmpdir/jailrun-seatbelt-$$.log"
+  log stream --style ndjson \
+    --predicate 'subsystem == "com.apple.sandbox" AND eventMessage CONTAINS "deny"' \
+    > "$_DENY_LOG_FILE" 2>/dev/null &
+  _DENY_LOG_PID=$!
+  # Verify the process actually started
+  if ! kill -0 "$_DENY_LOG_PID" 2>/dev/null; then
+    echo "[$_WRAPPER_NAME] WARN: failed to start deny log stream" >&2
+    _DENY_LOG_PID=""
+    _DENY_LOG_FILE=""
+  fi
+}
+
+# Stop deny event collection. Clears _DENY_LOG_PID but preserves _DENY_LOG_FILE
+# for upstream DEBUG display.
+_stop_deny_log() {
+  if [ -n "$_DENY_LOG_PID" ]; then
+    kill "$_DENY_LOG_PID" 2>/dev/null || true
+    wait "$_DENY_LOG_PID" 2>/dev/null || true
+    _DENY_LOG_PID=""
+  fi
+}

--- a/lib/platform/sandbox-darwin.sh
+++ b/lib/platform/sandbox-darwin.sh
@@ -64,6 +64,9 @@ _setup_sandbox() {
       for _p in $_SANDBOX_ALLOW_WRITE_PATHS; do
         echo "      (subpath \"$_p\")"
       done
+      for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
+        echo "      (subpath \"$_p\")"
+      done
       for _f in $_SANDBOX_ALLOW_WRITE_FILES; do
         echo "      (literal \"$_f\")"
       done

--- a/lib/platform/sandbox-darwin.sh
+++ b/lib/platform/sandbox-darwin.sh
@@ -8,6 +8,12 @@
 
 . "$JAILRUN_LIB/platform/git-worktree.sh"
 
+# Escape a path for Seatbelt string literals (subpath/literal expressions).
+# Handles backslash and double-quote characters that would break the profile.
+_seatbelt_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
 _setup_sandbox() {
   local _cwd="$PWD"
   _detect_git_worktree
@@ -36,7 +42,7 @@ _setup_sandbox() {
     _OLD_IFS="$IFS"; IFS="
 "
     for _p in $_SANDBOX_DENY_READ_PATHS; do
-      echo "  (subpath \"$_p\")"
+      echo "  (subpath \"$(_seatbelt_escape "$_p")\")"
     done
     IFS="$_OLD_IFS"
     echo ')'
@@ -46,9 +52,9 @@ _setup_sandbox() {
       echo '(deny file-write*'
       echo '  (require-not'
       echo '    (require-any'
-      echo "      (subpath \"$_cwd\")"
-      [ -n "$_git_parent_toplevel" ] && echo "      (subpath \"$_git_parent_toplevel\")"
-      [ -z "$_git_parent_toplevel" ] && [ -n "$_git_common_dir" ] && echo "      (subpath \"$_git_common_dir\")"
+      echo "      (subpath \"$(_seatbelt_escape "$_cwd")\")"
+      [ -n "$_git_parent_toplevel" ] && echo "      (subpath \"$(_seatbelt_escape "$_git_parent_toplevel")\")"
+      [ -z "$_git_parent_toplevel" ] && [ -n "$_git_common_dir" ] && echo "      (subpath \"$(_seatbelt_escape "$_git_common_dir")\")"
       echo '      (subpath "/tmp")'
       echo '      (subpath "/private/tmp")'
       echo '      (subpath "/private/var/folders")'
@@ -58,17 +64,17 @@ _setup_sandbox() {
       echo '      (literal "/dev/urandom")'
       echo '      (literal "/dev/tty")'
       echo '      (regex #"^/dev/ttys[0-9]+$")'
-      echo "      (subpath \"$_tmpdir\")"
+      echo "      (subpath \"$(_seatbelt_escape "$_tmpdir")\")"
       _OLD_IFS="$IFS"; IFS="
 "
       for _p in $_SANDBOX_ALLOW_WRITE_PATHS; do
-        echo "      (subpath \"$_p\")"
+        echo "      (subpath \"$(_seatbelt_escape "$_p")\")"
       done
       for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
-        echo "      (subpath \"$_p\")"
+        echo "      (subpath \"$(_seatbelt_escape "$_p")\")"
       done
       for _f in $_SANDBOX_ALLOW_WRITE_FILES; do
-        echo "      (literal \"$_f\")"
+        echo "      (literal \"$(_seatbelt_escape "$_f")\")"
       done
       for _re in $_SANDBOX_ALLOW_WRITE_REGEXES; do
         echo "      (regex #\"$_re\")"
@@ -82,7 +88,7 @@ _setup_sandbox() {
         _OLD_IFS="$IFS"; IFS="
 "
         for _wt in $_other_worktrees; do
-          echo "  (subpath \"$_wt\")"
+          echo "  (subpath \"$(_seatbelt_escape "$_wt")\")"
         done
         IFS="$_OLD_IFS"
         echo ')'

--- a/lib/platform/sandbox-darwin.sh
+++ b/lib/platform/sandbox-darwin.sh
@@ -70,6 +70,9 @@ _setup_sandbox() {
       for _f in $_SANDBOX_ALLOW_WRITE_FILES; do
         echo "      (literal \"$_f\")"
       done
+      for _re in $_SANDBOX_ALLOW_WRITE_REGEXES; do
+        echo "      (regex #\"$_re\")"
+      done
       IFS="$_OLD_IFS"
       echo ')))'
       if [ -n "$_other_worktrees" ]; then

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -122,6 +122,12 @@ _setup_sandbox() {
       echo "-p ReadWritePaths=$_p"
     done
 
+    # NOTE: _SANDBOX_ALLOW_WRITE_FILES and _SANDBOX_ALLOW_WRITE_REGEXES are
+    # not consumed by this backend. systemd does not support regex-based or
+    # single-file granularity permissions. Target files (e.g. ~/.claude.json,
+    # ~/.claude.json.tmp.*) are covered only if $_cwd includes $HOME.
+    # This platform asymmetry is documented in the design (by design).
+
     # Make sensitive directories inaccessible
     for _p in $_SANDBOX_DENY_READ_PATHS; do
       [ -d "$_p" ] && echo "-p InaccessiblePaths=$_p"

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -116,9 +116,11 @@ _setup_sandbox() {
     done
 
     # Lockfile directories: proper-lockfile creates <dir>.lock next to target.
-    # Pre-create so systemd can bind-mount them as read-write.
+    # Only add ReadWritePaths if the directory already exists. Do NOT pre-create
+    # with mkdir — proper-lockfile uses mkdir to acquire locks, so a pre-created
+    # directory would appear as a permanently held lock. See #23.
     for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
-      [ -d "$_p" ] || mkdir -p "$_p" 2>/dev/null || continue
+      [ -d "$_p" ] || continue
       echo "-p ReadWritePaths=$_p"
     done
 

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -115,6 +115,13 @@ _setup_sandbox() {
       echo "-p ReadWritePaths=$_p"
     done
 
+    # Lockfile directories: proper-lockfile creates <dir>.lock next to target.
+    # Pre-create so systemd can bind-mount them as read-write.
+    for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
+      [ -d "$_p" ] || mkdir -p "$_p" 2>/dev/null || continue
+      echo "-p ReadWritePaths=$_p"
+    done
+
     # Make sensitive directories inaccessible
     for _p in $_SANDBOX_DENY_READ_PATHS; do
       [ -d "$_p" ] && echo "-p InaccessiblePaths=$_p"

--- a/lib/platform/sandbox-linux.sh
+++ b/lib/platform/sandbox-linux.sh
@@ -13,3 +13,7 @@ else
   echo "[$_WRAPPER_NAME] ERROR: systemd-run not found. Cannot launch without sandbox." >&2
   exit 1
 fi
+
+# No-op deny log hooks (Linux does not support Seatbelt deny logging)
+_start_deny_log() { :; }
+_stop_deny_log() { :; }

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -44,6 +44,12 @@ do
 $_p"
 done
 # Platform-specific paths: add only if they already exist
+# SECURITY NOTE: ~/Library/Keychains is granted subpath write access because
+# macOS SecurityServer (securityd) requires file-level writes to Keychain DBs
+# when sandboxed apps refresh their own auth tokens (e.g. OAuth token rotation).
+# GitHub PAT and other sensitive credentials are protected by file-read deny
+# rules on ~/.config/gh and related directories. Narrowing to specific Keychain
+# files is a potential future improvement (requires macOS-specific testing).
 for _p in \
   "$HOME/Library/Application Support/Claude" \
   "$HOME/Library/Application Support/Codex" \

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -47,7 +47,8 @@ done
 for _p in \
   "$HOME/Library/Application Support/Claude" \
   "$HOME/Library/Application Support/Codex" \
-  "$HOME/Library/Application Support/kiro-cli"
+  "$HOME/Library/Application Support/kiro-cli" \
+  "$HOME/Library/Keychains"
 do
   [ -d "$_p" ] || continue
   _SANDBOX_ALLOW_WRITE_PATHS="$_SANDBOX_ALLOW_WRITE_PATHS
@@ -62,13 +63,14 @@ for _p in $SANDBOX_EXTRA_ALLOW_WRITE; do
 $_p"
 done
 
-# Lockfile paths: proper-lockfile creates <dir>.lock next to the target.
-# Claude Code's OAuth token refresh locks ~/.claude without specifying
-# lockfilePath, so proper-lockfile defaults to ~/.claude.lock in $HOME.
-# These paths must be writable even before the lock directory exists.
+# Lockfile paths: proper-lockfile creates <target>.lock next to the target.
+# Claude Code uses lock directories for multiple auth-related files, including
+# ~/.claude and ~/.claude.json. These paths must be writable even before the
+# lock directory exists.
 _SANDBOX_ALLOW_WRITE_LOCK_PATHS=""
 for _p in \
-  "$HOME/.claude.lock"
+  "$HOME/.claude.lock" \
+  "$HOME/.claude.json.lock"
 do
   _SANDBOX_ALLOW_WRITE_LOCK_PATHS="$_SANDBOX_ALLOW_WRITE_LOCK_PATHS
 $_p"
@@ -82,6 +84,13 @@ for _p in $SANDBOX_EXTRA_ALLOW_WRITE_FILES; do
   _SANDBOX_ALLOW_WRITE_FILES="$_SANDBOX_ALLOW_WRITE_FILES
 $_p"
 done
+
+_regex_escape() {
+  printf '%s' "$1" | sed 's/[][(){}.^$+*?|\\]/\\&/g'
+}
+
+_home_regex=$(_regex_escape "$HOME")
+_SANDBOX_ALLOW_WRITE_REGEXES="^${_home_regex}/\\.claude\\.json\\.tmp\\.[^/]+$"
 
 # ============================================================
 # Section 2: Platform backend loading

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -62,6 +62,18 @@ for _p in $SANDBOX_EXTRA_ALLOW_WRITE; do
 $_p"
 done
 
+# Lockfile paths: proper-lockfile creates <dir>.lock next to the target.
+# Claude Code's OAuth token refresh locks ~/.claude without specifying
+# lockfilePath, so proper-lockfile defaults to ~/.claude.lock in $HOME.
+# These paths must be writable even before the lock directory exists.
+_SANDBOX_ALLOW_WRITE_LOCK_PATHS=""
+for _p in \
+  "$HOME/.claude.lock"
+do
+  _SANDBOX_ALLOW_WRITE_LOCK_PATHS="$_SANDBOX_ALLOW_WRITE_LOCK_PATHS
+$_p"
+done
+
 _SANDBOX_ALLOW_WRITE_FILES="$HOME/.claude.json"
 for _p in $SANDBOX_EXTRA_ALLOW_WRITE_FILES; do
   case "$_p" in

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -310,8 +310,9 @@ credential_guard_sandbox_exec() {
 
   if [ -n "$_PROXY_PID" ] || [ -n "$_DENY_LOG_PID" ]; then
     # Proxy or deny log running — can't exec, need to wait and clean up
-    # EXIT trap ensures cleanup even if shell is killed by signal
-    trap '_stop_deny_log; [ -n "$_PROXY_PID" ] && kill "$_PROXY_PID" 2>/dev/null' EXIT
+    # EXIT trap ensures cleanup even if shell is killed by signal.
+    # Must include rm -rf to preserve credentials.sh's tmpdir cleanup.
+    trap '_stop_deny_log; [ -n "$_PROXY_PID" ] && kill "$_PROXY_PID" 2>/dev/null; rm -rf "$_tmpdir"' EXIT
     if [ -n "$_PROXY_PID" ]; then
       "$_tmpdir/exec-proxy.sh" "$@"
     else
@@ -329,6 +330,7 @@ credential_guard_sandbox_exec() {
       kill "$_PROXY_PID" 2>/dev/null || true
       wait "$_PROXY_PID" 2>/dev/null || true
     fi
+    rm -rf "$_tmpdir"
     exit "$_exit_code"
   else
     exec "$_tmpdir/exec.sh" "$@"

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -275,6 +275,13 @@ credential_guard_sandbox_exec() {
     _setup_sandbox
   fi
 
+  # Start deny log collection only in debug mode (Darwin: log stream, Linux: no-op)
+  _DENY_LOG_PID=""
+  _DENY_LOG_FILE=""
+  if [ "${AGENT_SANDBOX_DEBUG:-}" = "1" ]; then
+    _start_deny_log
+  fi
+
   # Start proxy if enabled
   _PROXY_PORT=""
   _PROXY_PID=""
@@ -301,12 +308,27 @@ credential_guard_sandbox_exec() {
   fi
   [ "${AGENT_SANDBOX_DEBUG:-}" = "1" ] && echo "[$_WRAPPER_NAME] exec: $_sandbox_cmd $*" >&2
 
-  if [ -n "$_PROXY_PID" ]; then
-    # Proxy is running — can't exec, need to wait and clean up
-    "$_tmpdir/exec-proxy.sh" "$@"
+  if [ -n "$_PROXY_PID" ] || [ -n "$_DENY_LOG_PID" ]; then
+    # Proxy or deny log running — can't exec, need to wait and clean up
+    # EXIT trap ensures cleanup even if shell is killed by signal
+    trap '_stop_deny_log; [ -n "$_PROXY_PID" ] && kill "$_PROXY_PID" 2>/dev/null' EXIT
+    if [ -n "$_PROXY_PID" ]; then
+      "$_tmpdir/exec-proxy.sh" "$@"
+    else
+      "$_tmpdir/exec.sh" "$@"
+    fi
     _exit_code=$?
-    kill "$_PROXY_PID" 2>/dev/null || true
-    wait "$_PROXY_PID" 2>/dev/null || true
+    trap - EXIT
+    _stop_deny_log
+    if [ -n "$_DENY_LOG_FILE" ] && [ -s "$_DENY_LOG_FILE" ]; then
+      echo "[$_WRAPPER_NAME] === Seatbelt deny log ===" >&2
+      cat "$_DENY_LOG_FILE" >&2
+      echo "[$_WRAPPER_NAME] === end deny log ===" >&2
+    fi
+    if [ -n "$_PROXY_PID" ]; then
+      kill "$_PROXY_PID" 2>/dev/null || true
+      wait "$_PROXY_PID" 2>/dev/null || true
+    fi
     exit "$_exit_code"
   else
     exec "$_tmpdir/exec.sh" "$@"

--- a/tests/sandbox_deny_log.bats
+++ b/tests/sandbox_deny_log.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "_start_deny_log sets _DENY_LOG_PID and _DENY_LOG_FILE on Darwin" {
+  if [ "$(uname)" != "Darwin" ]; then
+    skip "Darwin-only test"
+  fi
+  setup_jailrun_env
+  _tmpdir=$(mktemp -d)
+  _WRAPPER_NAME=jailrun
+
+  . "$JAILRUN_LIB/platform/sandbox-darwin.sh"
+
+  _start_deny_log
+
+  [ -n "$_DENY_LOG_PID" ]
+  [ -n "$_DENY_LOG_FILE" ]
+  [ -f "$_DENY_LOG_FILE" ]
+
+  # Clean up
+  _stop_deny_log
+  rm -rf "$_tmpdir"
+}
+
+@test "_stop_deny_log clears _DENY_LOG_PID but preserves _DENY_LOG_FILE" {
+  if [ "$(uname)" != "Darwin" ]; then
+    skip "Darwin-only test"
+  fi
+  setup_jailrun_env
+  _tmpdir=$(mktemp -d)
+  _WRAPPER_NAME=jailrun
+
+  . "$JAILRUN_LIB/platform/sandbox-darwin.sh"
+
+  _start_deny_log
+  _saved_file="$_DENY_LOG_FILE"
+  _stop_deny_log
+
+  [ -z "$_DENY_LOG_PID" ]
+  [ "$_DENY_LOG_FILE" = "$_saved_file" ]
+
+  rm -rf "$_tmpdir"
+}
+
+@test "_stop_deny_log is safe to call when no log is running" {
+  if [ "$(uname)" != "Darwin" ]; then
+    skip "Darwin-only test"
+  fi
+  setup_jailrun_env
+
+  . "$JAILRUN_LIB/platform/sandbox-darwin.sh"
+
+  _DENY_LOG_PID=""
+  _DENY_LOG_FILE=""
+  run _stop_deny_log
+  [ "$status" -eq 0 ]
+}
+
+@test "sandbox-linux.sh defines no-op _start_deny_log and _stop_deny_log" {
+  if [ "$(uname)" = "Darwin" ]; then
+    # On macOS, verify that the no-op definitions exist in the file
+    run grep -c '_start_deny_log\|_stop_deny_log' "$BATS_TEST_DIRNAME/../lib/platform/sandbox-linux.sh"
+    [ "$output" -ge 2 ]
+  else
+    setup_jailrun_env
+    _tmpdir=$(mktemp -d)
+    _WRAPPER_NAME=jailrun
+
+    . "$JAILRUN_LIB/platform/sandbox-linux.sh"
+
+    _DENY_LOG_PID=""
+    _DENY_LOG_FILE=""
+    _start_deny_log
+    [ -z "$_DENY_LOG_PID" ]
+
+    rm -rf "$_tmpdir"
+  fi
+}

--- a/tests/sandbox_profile.bats
+++ b/tests/sandbox_profile.bats
@@ -36,7 +36,7 @@ CONF
   [[ "$output" != *'(deny mach-lookup (global-name "com.apple.SecurityServer"))'* ]]
 }
 
-@test "seatbelt profile includes lockfile paths for token refresh" {
+@test "seatbelt profile includes lockfile paths for auth refresh" {
   setup_jailrun_env
   export _CREDENTIAL_GUARD_SANDBOXED=""
 
@@ -59,8 +59,62 @@ CONF
   ' 2>/dev/null
 
   [ "$status" -eq 0 ]
-  # proper-lockfile creates <dir>.lock next to target; must be writable
+  # proper-lockfile creates <target>.lock next to target; both must be writable
   [[ "$output" == *'.claude.lock")'* ]]
+  [[ "$output" == *'.claude.json.lock")'* ]]
+}
+
+@test "seatbelt profile allows writing under Library/Keychains" {
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    export WRAPPER_NAME=claude
+    export XDG_CONFIG_HOME="'"$(mktemp -d)"'"
+    mkdir -p "$XDG_CONFIG_HOME/jailrun"
+    mkdir -p "$HOME/Library/Keychains"
+    cat > "$XDG_CONFIG_HOME/jailrun/config.toml" <<CONF
+[global]
+allowed_aws_profiles = []
+default_aws_profile = ""
+gh_token_name = "classic"
+CONF
+    . "$JAILRUN_LIB/config.sh"
+    . "$JAILRUN_LIB/credentials.sh"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _setup_sandbox
+    grep -n "Library/Keychains" "$_tmpdir/sandbox.sb"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'subpath "'$HOME'/Library/Keychains"'* ]]
+}
+
+@test "seatbelt profile includes temp config regex for atomic writes" {
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    export WRAPPER_NAME=claude
+    export XDG_CONFIG_HOME="'"$(mktemp -d)"'"
+    mkdir -p "$XDG_CONFIG_HOME/jailrun"
+    cat > "$XDG_CONFIG_HOME/jailrun/config.toml" <<CONF
+[global]
+allowed_aws_profiles = []
+default_aws_profile = ""
+gh_token_name = "classic"
+CONF
+    . "$JAILRUN_LIB/config.sh"
+    . "$JAILRUN_LIB/credentials.sh"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _setup_sandbox
+    grep -n "claude\\\\.json\\\\.tmp" "$_tmpdir/sandbox.sb"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'.claude\.json\.tmp'* ]]
 }
 
 @test "exec.sh contains sandbox-exec and env setup" {

--- a/tests/sandbox_profile.bats
+++ b/tests/sandbox_profile.bats
@@ -36,6 +36,33 @@ CONF
   [[ "$output" != *'(deny mach-lookup (global-name "com.apple.SecurityServer"))'* ]]
 }
 
+@test "seatbelt profile includes lockfile paths for token refresh" {
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    export WRAPPER_NAME=claude
+    export XDG_CONFIG_HOME="'"$(mktemp -d)"'"
+    mkdir -p "$XDG_CONFIG_HOME/jailrun"
+    cat > "$XDG_CONFIG_HOME/jailrun/config.toml" <<CONF
+[global]
+allowed_aws_profiles = []
+default_aws_profile = ""
+gh_token_name = "classic"
+CONF
+    . "$JAILRUN_LIB/config.sh"
+    . "$JAILRUN_LIB/credentials.sh"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _setup_sandbox
+    cat "$_tmpdir/sandbox.sb"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  # proper-lockfile creates <dir>.lock next to target; must be writable
+  [[ "$output" == *'.claude.lock")'* ]]
+}
+
 @test "exec.sh contains sandbox-exec and env setup" {
   setup_jailrun_env
 


### PR DESCRIPTION
## Summary
サンドボックスプロファイル修正の正式化とdenyログ機能追加。
WIPで実装済みのKeychain許可・lockfile・atomic write対応を正式化し、Seatbelt denyログの自動記録機能を追加。

## 受け入れ基準
- [x] sandbox.sh のlockfileパス・atomic write regex・Keychainパス追加が正式コードとしてレビュー済み
- [x] sandbox-darwin.sh のSeatbeltプロファイル出力にlockfile subpath・write regexが含まれている
- [x] sandbox-linux-systemd.sh のReadWritePathsにlockfileディレクトリが含まれている
- [x] sandbox_profile.bats の全テスト通過
- [x] macOSでSeatbelt denyイベントがPID付きログファイルに記録される
- [x] `log stream` 起動失敗時もjailrun本体は正常に起動する
- [x] `AGENT_SANDBOX_DEBUG=1` 設定時にdenyログをstderrにも出力する
- [x] docs/README.md にdenyログ機能・Write Allowancesの説明が追加されている
- [x] docs/architecture.md にdenyログのアーキテクチャ説明が追加されている

## 変更概要
- **Unit 001**: サンドボックスプロファイル修正の正式化
  - Keychain書き込み許可、lockfileパス、atomic write regex の正式化
  - 既存テスト全通過確認
- **Unit 002**: Seatbelt denyログの自動記録
  - `_start_deny_log()` / `_stop_deny_log()` によるdenyイベント収集
  - `log stream` バックグラウンド起動、PID付きログファイル
  - 起動失敗時のstderr警告、DEBUGモードでのstderr表示
- **Unit 003**: ドキュメント更新
  - README: Write Allowances、Seatbelt Deny Log セクション追加
  - Architecture: Data Flow deny log hook、Write Path Composition、Deny Log Architecture追加

## Test plan
- [x] 全78テスト通過（sandbox_profile.bats含む）

## Review Summary
- [Unit 001 Review Summary](https://github.com/ikeisuke/jailrun/blob/cycle/v0.2.0/.aidlc/cycles/v0.2.0/construction/units/001-review-summary.md)
- [Unit 002 Review Summary](https://github.com/ikeisuke/jailrun/blob/cycle/v0.2.0/.aidlc/cycles/v0.2.0/construction/units/002-review-summary.md)
- [Unit 003 Review Summary](https://github.com/ikeisuke/jailrun/blob/cycle/v0.2.0/.aidlc/cycles/v0.2.0/construction/units/003-review-summary.md)
