### PR TITLE
feat: sandbox_deny_read_names - ファイル名パターンによる読み取り拒否

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -31,6 +31,7 @@ DEFAULTS: dict = {
     "allowed_aws_profiles": ["default"],
     "default_aws_profile": "default",
     "default_region": "ap-northeast-1",
+    "sandbox_deny_read_names": [],
     "sandbox_extra_deny_read": [],
     "sandbox_extra_allow_write": [],
     "sandbox_extra_allow_write_files": [],
@@ -44,6 +45,7 @@ VALID_KEYCHAIN_PROFILES = {"deny", "read-cache-only", "allow"}
 
 LIST_KEYS = {
     "allowed_aws_profiles",
+    "sandbox_deny_read_names",
     "sandbox_extra_deny_read",
     "sandbox_extra_allow_write",
     "sandbox_extra_allow_write_files",
@@ -62,6 +64,9 @@ gh_token_name = "classic"
 allowed_aws_profiles = ["default"]
 default_aws_profile = "default"
 # default_region = "ap-northeast-1"
+
+# deny read by filename (matched anywhere in the filesystem, macOS only)
+# sandbox_deny_read_names = [".env"]
 
 # additional read-deny paths (default: ~/.aws ~/.ssh ~/.gnupg ~/.config/gh)
 # sandbox_extra_deny_read = []

--- a/lib/platform/sandbox-darwin.sh
+++ b/lib/platform/sandbox-darwin.sh
@@ -2,8 +2,9 @@
 # macOS Seatbelt sandbox backend
 # Sourced by sandbox.sh
 #
-# Requires: $_tmpdir, $_SANDBOX_DENY_READ_PATHS, $_SANDBOX_ALLOW_WRITE_PATHS,
-#           $_SANDBOX_ALLOW_WRITE_FILES to be set (newline-separated)
+# Requires: $_tmpdir, $_SANDBOX_DENY_READ_PATHS, $_SANDBOX_DENY_READ_REGEXES,
+#           $_SANDBOX_ALLOW_WRITE_PATHS, $_SANDBOX_ALLOW_WRITE_FILES
+#           to be set (newline-separated)
 # Provides: _setup_sandbox(), _build_sandbox_exec()
 
 . "$JAILRUN_LIB/platform/git-worktree.sh"
@@ -43,6 +44,9 @@ _setup_sandbox() {
 "
     for _p in $_SANDBOX_DENY_READ_PATHS; do
       echo "  (subpath \"$(_seatbelt_escape "$_p")\")"
+    done
+    for _re in $_SANDBOX_DENY_READ_REGEXES; do
+      echo "  (regex #\"$_re\")"
     done
     IFS="$_OLD_IFS"
     echo ')'
@@ -130,3 +134,6 @@ _stop_deny_log() {
     _DENY_LOG_PID=""
   fi
 }
+
+# No-op: AppArmor cleanup is Linux-only
+_cleanup_sandbox() { :; }

--- a/lib/platform/sandbox-linux-apparmor.sh
+++ b/lib/platform/sandbox-linux-apparmor.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# Linux AppArmor filesystem sandbox backend
+# Sourced by sandbox-linux.sh when AppArmor is available
+#
+# Requires: $_tmpdir, $_WRAPPER_NAME,
+#           $_SANDBOX_DENY_READ_PATHS, $_SANDBOX_DENY_READ_REGEXES,
+#           $_SANDBOX_ALLOW_WRITE_PATHS, $_SANDBOX_ALLOW_WRITE_LOCK_PATHS,
+#           $_SANDBOX_ALLOW_WRITE_FILES,
+#           $_git_parent_toplevel, $_git_common_dir, $_other_worktrees
+# Provides: _build_apparmor_profile(), _load_apparmor_profile(),
+#           _cleanup_sandbox()
+
+# Escape a path for AppArmor double-quoted string context.
+# Handles backslash and double-quote characters.
+_apparmor_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# Build AppArmor profile file at $_tmpdir/apparmor-profile.
+# Sets $_apparmor_profile_name.
+_build_apparmor_profile() {
+  local _cwd="$PWD"
+  local _profile="$_tmpdir/apparmor-profile"
+
+  # Generate unique profile name
+  _aa_rand=$(od -An -tx2 -N2 /dev/urandom | tr -d ' ')
+  _apparmor_profile_name="jailrun_$(id -u)_$$_${_aa_rand}"
+
+  {
+    echo '#include <tunables/global>'
+    echo ''
+    printf 'profile %s flags=(attach_disconnected) {\n' "$_apparmor_profile_name"
+    echo '  #include <abstractions/base>'
+    echo ''
+    echo '  # Default: allow read and execute everywhere'
+    echo '  / r,'
+    echo '  /** r,'
+    echo '  /** ix,'
+
+    _OLD_IFS="$IFS"; IFS="
+"
+    echo ''
+    echo '  # Deny read: sensitive directories'
+    for _p in $_SANDBOX_DENY_READ_PATHS; do
+      echo "  deny \"$(_apparmor_escape "$_p")\"/ r,"
+      echo "  deny \"$(_apparmor_escape "$_p")\"/** r,"
+    done
+
+    # Deny read: filename patterns (converted from regex to AppArmor glob)
+    if [ -n "$_SANDBOX_DENY_READ_REGEXES" ]; then
+      echo ''
+      echo '  # Deny read: filename patterns'
+      for _re in $_SANDBOX_DENY_READ_REGEXES; do
+        # Input format: /<regex_escaped_name>$ (e.g. /\.env$)
+        # Strip leading /, strip trailing $, remove regex escapes
+        _name="${_re#/}"
+        _name="${_name%?}"
+        _name=$(printf '%s' "$_name" | sed 's/\\//g')
+        echo "  deny /**/${_name} r,"
+      done
+    fi
+
+    echo ''
+    echo '  # Write whitelist'
+    echo "  \"$(_apparmor_escape "$_cwd")\"/ rw,"
+    echo "  \"$(_apparmor_escape "$_cwd")\"/** rwk,"
+    echo '  /tmp/ rw,'
+    echo '  /tmp/** rw,'
+    echo "  \"$(_apparmor_escape "$_tmpdir")\"/ rw,"
+    echo "  \"$(_apparmor_escape "$_tmpdir")\"/** rw,"
+
+    if [ -n "$_git_parent_toplevel" ]; then
+      echo "  \"$(_apparmor_escape "$_git_parent_toplevel")\"/ rw,"
+      echo "  \"$(_apparmor_escape "$_git_parent_toplevel")\"/** rwk,"
+    elif [ -n "$_git_common_dir" ]; then
+      echo "  \"$(_apparmor_escape "$_git_common_dir")\"/ rw,"
+      echo "  \"$(_apparmor_escape "$_git_common_dir")\"/** rwk,"
+    fi
+
+    for _p in $_SANDBOX_ALLOW_WRITE_PATHS; do
+      echo "  \"$(_apparmor_escape "$_p")\"/ rw,"
+      echo "  \"$(_apparmor_escape "$_p")\"/** rw,"
+    done
+
+    for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
+      echo "  \"$(_apparmor_escape "$_p")\"/ rwk,"
+      echo "  \"$(_apparmor_escape "$_p")\"/** rwk,"
+    done
+
+    for _f in $_SANDBOX_ALLOW_WRITE_FILES; do
+      echo "  \"$(_apparmor_escape "$_f")\" rw,"
+      # Allow atomic write temp files (proper-lockfile pattern)
+      echo "  \"$(_apparmor_escape "$_f")\".tmp.* rw,"
+    done
+
+    if [ -n "$_other_worktrees" ]; then
+      echo ''
+      echo '  # Deny writes to other worktrees'
+      for _wt in $_other_worktrees; do
+        echo "  deny \"$(_apparmor_escape "$_wt")\"/ w,"
+        echo "  deny \"$(_apparmor_escape "$_wt")\"/** w,"
+      done
+    fi
+
+    echo ''
+    echo '  # Config directory: read-only'
+    _config_path="${CONFIG_DIR:-$HOME/.config/jailrun}"
+    echo "  deny \"$(_apparmor_escape "$_config_path")\"/ w,"
+    echo "  deny \"$(_apparmor_escape "$_config_path")\"/** w,"
+
+    echo ''
+    echo '  # D-Bus session bus socket'
+    echo '  deny /run/user/*/bus rw,'
+
+    IFS="$_OLD_IFS"
+    echo '}'
+  } > "$_profile"
+}
+
+# Load AppArmor profile into kernel. Returns 0 on success.
+_load_apparmor_profile() {
+  if sudo -n apparmor_parser -r "$_tmpdir/apparmor-profile" 2>/dev/null; then
+    _APPARMOR_PROFILE_LOADED=1
+    return 0
+  fi
+  echo "[$_WRAPPER_NAME] WARN: failed to load AppArmor profile (sudo required), falling back to systemd" >&2
+  _APPARMOR_PROFILE_LOADED=""
+  return 1
+}
+
+# Unload AppArmor profile from kernel (called by sandbox.sh EXIT trap)
+_cleanup_sandbox() {
+  if [ -n "${_APPARMOR_PROFILE_LOADED:-}" ] && [ -f "$_tmpdir/apparmor-profile" ]; then
+    sudo -n apparmor_parser -R "$_tmpdir/apparmor-profile" 2>/dev/null || true
+  fi
+}

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -11,6 +11,13 @@ _setup_sandbox() {
   local _cwd="$PWD"
   _detect_git_worktree
 
+  # Try AppArmor for filesystem control
+  _APPARMOR_PROFILE_LOADED=""
+  if [ "${_APPARMOR_AVAILABLE:-}" = "1" ]; then
+    _build_apparmor_profile
+    _load_apparmor_profile || true
+  fi
+
   _sandbox_cmd="systemd-run"
   local _props="$_tmpdir/systemd-props"
   {
@@ -42,10 +49,12 @@ _setup_sandbox() {
       echo '-p IPAddressAllow=::1/128'
     fi
     # Filesystem
-    echo '-p ProtectSystem=strict'
-    echo '-p ProtectHome=read-only'
-    echo "-p ReadWritePaths=$_cwd"
-    echo "-p ReadWritePaths=$_tmpdir"
+    if [ -z "${_APPARMOR_PROFILE_LOADED:-}" ]; then
+      echo '-p ProtectSystem=strict'
+      echo '-p ProtectHome=read-only'
+      echo "-p ReadWritePaths=$_cwd"
+      echo "-p ReadWritePaths=$_tmpdir"
+    fi
     # Kernel protection
     echo '-p ProtectProc=invisible'
     echo '-p ProtectClock=yes'
@@ -66,14 +75,9 @@ _setup_sandbox() {
     echo '-p UMask=0077'
     echo '-p CoredumpFilter=0'
     echo '-p KeyringMode=private'
+
     # Block D-Bus session bus (prevents GNOME Keyring / secret-tool access)
-    # 1. Block default XDG user bus socket
-    _xdg_runtime="${XDG_RUNTIME_DIR:-}"
-    if [ -n "$_xdg_runtime" ] && [ -S "$_xdg_runtime/bus" ]; then
-      echo "-p InaccessiblePaths=$_xdg_runtime/bus"
-    fi
-    # 2. Block socket from DBUS_SESSION_BUS_ADDRESS if it contains a file path
-    #    Handles formats: unix:path=/x, unix:guid=...,path=/x, etc.
+    # Detect socket type for _DBUS_NEEDS_ENV_CLEAR (used by env-spec)
     _dbus_addr="${DBUS_SESSION_BUS_ADDRESS:-}"
     _dbus_sock=""
     case "$_dbus_addr" in
@@ -83,60 +87,79 @@ _setup_sandbox() {
         _dbus_sock="${_dbus_tail%%,*}"
         _dbus_sock="${_dbus_sock%%;*}" ;;
     esac
-    if [ -n "$_dbus_sock" ] && [ -S "$_dbus_sock" ]; then
-      echo "-p InaccessiblePaths=$_dbus_sock"
-    else
+    if [ -z "$_dbus_sock" ] || [ ! -S "$_dbus_sock" ]; then
       # Abstract sockets or unresolvable: clear the address as fallback
       _DBUS_NEEDS_ENV_CLEAR=1
     fi
-    # Explicit write protection for config directory
-    echo "-p ReadOnlyPaths=${CONFIG_DIR:-$HOME/.config/jailrun}"
-
-    # Git worktree
-    if [ -n "$_git_parent_toplevel" ]; then
-      echo "-p ReadWritePaths=$_git_parent_toplevel"
-      if [ -n "$_other_worktrees" ]; then
-        _OLD_IFS="$IFS"; IFS="
-"
-        for _wt in $_other_worktrees; do
-          [ -d "$_wt" ] && echo "-p InaccessiblePaths=$_wt"
-        done
-        IFS="$_OLD_IFS"
+    if [ -z "${_APPARMOR_PROFILE_LOADED:-}" ]; then
+      # Block via InaccessiblePaths (systemd filesystem control mode)
+      _xdg_runtime="${XDG_RUNTIME_DIR:-}"
+      if [ -n "$_xdg_runtime" ] && [ -S "$_xdg_runtime/bus" ]; then
+        echo "-p InaccessiblePaths=$_xdg_runtime/bus"
       fi
-    elif [ -n "$_git_common_dir" ]; then
-      echo "-p ReadWritePaths=$_git_common_dir"
+      if [ -n "$_dbus_sock" ] && [ -S "$_dbus_sock" ]; then
+        echo "-p InaccessiblePaths=$_dbus_sock"
+      fi
     fi
 
-    # Make whitelisted directories writable
-    _OLD_IFS="$IFS"; IFS="
+    if [ -z "${_APPARMOR_PROFILE_LOADED:-}" ]; then
+      # --- systemd filesystem control (fallback when AppArmor unavailable) ---
+
+      # Explicit write protection for config directory
+      echo "-p ReadOnlyPaths=${CONFIG_DIR:-$HOME/.config/jailrun}"
+
+      # Git worktree
+      if [ -n "$_git_parent_toplevel" ]; then
+        echo "-p ReadWritePaths=$_git_parent_toplevel"
+        if [ -n "$_other_worktrees" ]; then
+          _OLD_IFS="$IFS"; IFS="
 "
-    for _p in $_SANDBOX_ALLOW_WRITE_PATHS; do
-      [ -d "$_p" ] || continue
-      echo "-p ReadWritePaths=$_p"
-    done
+          for _wt in $_other_worktrees; do
+            [ -d "$_wt" ] && echo "-p InaccessiblePaths=$_wt"
+          done
+          IFS="$_OLD_IFS"
+        fi
+      elif [ -n "$_git_common_dir" ]; then
+        echo "-p ReadWritePaths=$_git_common_dir"
+      fi
 
-    # Lockfile directories: proper-lockfile creates <dir>.lock next to target.
-    # Only add ReadWritePaths if the directory already exists. Do NOT pre-create
-    # with mkdir — proper-lockfile uses mkdir to acquire locks, so a pre-created
-    # directory would appear as a permanently held lock. See #23.
-    for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
-      [ -d "$_p" ] || continue
-      echo "-p ReadWritePaths=$_p"
-    done
+      # Make whitelisted directories writable
+      _OLD_IFS="$IFS"; IFS="
+"
+      for _p in $_SANDBOX_ALLOW_WRITE_PATHS; do
+        [ -d "$_p" ] || continue
+        echo "-p ReadWritePaths=$_p"
+      done
 
-    # NOTE: _SANDBOX_ALLOW_WRITE_FILES and _SANDBOX_ALLOW_WRITE_REGEXES are
-    # not consumed by this backend. systemd does not support regex-based or
-    # single-file granularity permissions. Target files (e.g. ~/.claude.json,
-    # ~/.claude.json.tmp.*) are covered only if $_cwd includes $HOME.
-    # This platform asymmetry is documented in the design (by design).
+      # Lockfile directories: proper-lockfile creates <dir>.lock next to target.
+      # Only add ReadWritePaths if the directory already exists. Do NOT pre-create
+      # with mkdir — proper-lockfile uses mkdir to acquire locks, so a pre-created
+      # directory would appear as a permanently held lock. See #23.
+      for _p in $_SANDBOX_ALLOW_WRITE_LOCK_PATHS; do
+        [ -d "$_p" ] || continue
+        echo "-p ReadWritePaths=$_p"
+      done
 
-    # Make sensitive paths inaccessible (directories and files).
-    # NOTE: InaccessiblePaths requires the path to exist; non-existent paths
-    # are skipped. Paths created after sandbox startup are NOT protected.
-    for _p in $_SANDBOX_DENY_READ_PATHS; do
-      [ -e "$_p" ] && echo "-p InaccessiblePaths=$_p"
-    done
-    IFS="$_OLD_IFS"
+      # NOTE: _SANDBOX_ALLOW_WRITE_FILES and _SANDBOX_ALLOW_WRITE_REGEXES are
+      # not consumed in systemd-only mode. systemd does not support regex-based
+      # or single-file granularity permissions. Target files (e.g. ~/.claude.json,
+      # ~/.claude.json.tmp.*) are covered only if $_cwd includes $HOME.
+
+      # Make sensitive paths inaccessible (directories and files).
+      # NOTE: InaccessiblePaths requires the path to exist; non-existent paths
+      # are skipped. Paths created after sandbox startup are NOT protected.
+      for _p in $_SANDBOX_DENY_READ_PATHS; do
+        [ -e "$_p" ] && echo "-p InaccessiblePaths=$_p"
+      done
+
+      # NOTE: _SANDBOX_DENY_READ_REGEXES is not consumed in systemd-only mode.
+      # Filename-based deny (sandbox_deny_read_names) requires AppArmor.
+
+      IFS="$_OLD_IFS"
+    else
+      # --- AppArmor handles all filesystem control ---
+      echo "-p AppArmorProfile=$_apparmor_profile_name"
+    fi
   } > "$_props"
 }
 

--- a/lib/platform/sandbox-linux.sh
+++ b/lib/platform/sandbox-linux.sh
@@ -7,6 +7,15 @@
 
 . "$JAILRUN_LIB/platform/git-worktree.sh"
 
+# Detect AppArmor availability (kernel enabled + userspace tools)
+_APPARMOR_AVAILABLE=""
+if [ -f /sys/module/apparmor/parameters/enabled ] && \
+   [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = "Y" ] && \
+   command -v apparmor_parser >/dev/null 2>&1; then
+  _APPARMOR_AVAILABLE=1
+  . "$JAILRUN_LIB/platform/sandbox-linux-apparmor.sh"
+fi
+
 if command -v systemd-run >/dev/null 2>&1; then
   . "$JAILRUN_LIB/platform/sandbox-linux-systemd.sh"
 else
@@ -14,6 +23,16 @@ else
   exit 1
 fi
 
+# Warn if sandbox_deny_read_names is set but AppArmor is not available
+if [ "${_APPARMOR_AVAILABLE:-}" != "1" ] && [ -n "${SANDBOX_DENY_READ_NAMES:-}" ]; then
+  echo "[$_WRAPPER_NAME] WARN: sandbox_deny_read_names requires AppArmor, ignoring" >&2
+fi
+
 # No-op deny log hooks (Linux does not support Seatbelt deny logging)
 _start_deny_log() { :; }
 _stop_deny_log() { :; }
+
+# Cleanup hook (overridden by sandbox-linux-apparmor.sh when AppArmor is active)
+if [ "${_APPARMOR_AVAILABLE:-}" != "1" ]; then
+  _cleanup_sandbox() { :; }
+fi

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -127,6 +127,14 @@ _regex_escape() {
 _home_regex=$(_regex_escape "$HOME")
 _SANDBOX_ALLOW_WRITE_REGEXES="^${_home_regex}/\\.claude\\.json\\.tmp\\.[^/]+$"
 
+# Build deny-read regexes from filename list (e.g. ".env" -> /\.env$)
+_SANDBOX_DENY_READ_REGEXES=""
+for _name in $SANDBOX_DENY_READ_NAMES; do
+  _escaped=$(_regex_escape "$_name")
+  _SANDBOX_DENY_READ_REGEXES="$_SANDBOX_DENY_READ_REGEXES
+/$_escaped\$"
+done
+
 # ============================================================
 # Section 2: Platform backend loading
 # ============================================================
@@ -337,11 +345,11 @@ credential_guard_sandbox_exec() {
   fi
   [ "${AGENT_SANDBOX_DEBUG:-}" = "1" ] && echo "[$_WRAPPER_NAME] exec: $_sandbox_cmd $*" >&2
 
-  if [ -n "$_PROXY_PID" ] || [ -n "$_DENY_LOG_PID" ]; then
+  if [ -n "$_PROXY_PID" ] || [ -n "$_DENY_LOG_PID" ] || [ -n "${_APPARMOR_PROFILE_LOADED:-}" ]; then
     # Proxy or deny log running — can't exec, need to wait and clean up
     # EXIT trap ensures cleanup even if shell is killed by signal.
     # Must include rm -rf to preserve credentials.sh's tmpdir cleanup.
-    trap '_stop_deny_log; [ -n "$_PROXY_PID" ] && kill "$_PROXY_PID" 2>/dev/null; rm -rf "$_tmpdir"' EXIT
+    trap '_stop_deny_log; _cleanup_sandbox; [ -n "$_PROXY_PID" ] && kill "$_PROXY_PID" 2>/dev/null; rm -rf "$_tmpdir"' EXIT
     if [ -n "$_PROXY_PID" ]; then
       "$_tmpdir/exec-proxy.sh" "$@"
     else
@@ -359,6 +367,7 @@ credential_guard_sandbox_exec() {
       kill "$_PROXY_PID" 2>/dev/null || true
       wait "$_PROXY_PID" 2>/dev/null || true
     fi
+    _cleanup_sandbox
     rm -rf "$_tmpdir"
     exit "$_exit_code"
   else

--- a/tests/sandbox_linux_apparmor.bats
+++ b/tests/sandbox_linux_apparmor.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+
+# Tests for lib/platform/sandbox-linux-apparmor.sh
+# Verifies AppArmor profile generation and systemd integration.
+# These tests run on any platform (profile generation is pure text output).
+
+load helpers
+
+setup() {
+  setup_jailrun_env
+  _tmpdir=$(mktemp -d)
+  export _tmpdir
+}
+
+teardown() {
+  rm -rf "$_tmpdir"
+}
+
+# Helper: run _setup_sandbox with AppArmor enabled, output both files
+run_setup_with_apparmor() {
+  run sh -c '
+    _tmpdir="'"$_tmpdir"'"
+    _git_parent_toplevel="'"${_git_parent_toplevel:-}"'"
+    _git_common_dir="'"${_git_common_dir:-}"'"
+    _other_worktrees="'"${_other_worktrees:-}"'"
+    _SANDBOX_ALLOW_WRITE_PATHS="'"${_SANDBOX_ALLOW_WRITE_PATHS:-}"'"
+    _SANDBOX_ALLOW_WRITE_LOCK_PATHS="'"${_SANDBOX_ALLOW_WRITE_LOCK_PATHS:-}"'"
+    _SANDBOX_ALLOW_WRITE_FILES="'"${_SANDBOX_ALLOW_WRITE_FILES:-}"'"
+    _SANDBOX_DENY_READ_PATHS="'"${_SANDBOX_DENY_READ_PATHS:-}"'"
+    _WRAPPER_NAME="claude"
+    _APPARMOR_AVAILABLE=1
+    export PROXY_ENABLED="'"${PROXY_ENABLED:-false}"'"
+    _detect_git_worktree() { :; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-apparmor.sh"
+    # Override _load to succeed without sudo
+    _load_apparmor_profile() { _APPARMOR_PROFILE_LOADED=1; return 0; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-systemd.sh"
+    _setup_sandbox
+    echo "=== APPARMOR ==="
+    cat "$_tmpdir/apparmor-profile"
+    echo "=== PROPS ==="
+    cat "$_tmpdir/systemd-props"
+  '
+}
+
+# Helper: extract AppArmor profile section from output
+get_apparmor() {
+  echo "$output" | sed -n '/=== APPARMOR ===/,/=== PROPS ===/p' | sed '1d;$d'
+}
+
+# Helper: extract systemd-props section from output
+get_props() {
+  echo "$output" | sed -n '/=== PROPS ===/,$p' | sed '1d'
+}
+
+# --- AppArmor profile structure ---
+
+@test "apparmor profile includes header and abstractions" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"#include <tunables/global>"* ]]
+  [[ "$_aa" == *"#include <abstractions/base>"* ]]
+  [[ "$_aa" == *"profile jailrun_"* ]]
+  [[ "$_aa" == *"flags=(attach_disconnected)"* ]]
+}
+
+@test "apparmor profile allows read and execute by default" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"/** r,"* ]]
+  [[ "$_aa" == *"/** ix,"* ]]
+}
+
+@test "apparmor profile denies read for sensitive paths" {
+  _SANDBOX_DENY_READ_PATHS="/home/testuser/.aws
+/home/testuser/.ssh"
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *'deny "/home/testuser/.aws"/** r,'* ]]
+  [[ "$_aa" == *'deny "/home/testuser/.ssh"/** r,'* ]]
+}
+
+@test "apparmor profile denies read for non-existent paths" {
+  _SANDBOX_DENY_READ_PATHS="/nonexistent/secret/path"
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  # Unlike systemd InaccessiblePaths, AppArmor handles non-existent paths
+  [[ "$_aa" == *'deny "/nonexistent/secret/path"/** r,'* ]]
+}
+
+@test "apparmor profile includes write whitelist for cwd and tmp" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"/tmp/** rw,"* ]]
+  [[ "$_aa" == *"/** rwk,"* ]]
+}
+
+@test "apparmor profile denies D-Bus socket" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"deny /run/user/*/bus rw,"* ]]
+}
+
+@test "apparmor profile denies writes to config directory" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *'deny "'*'/jailrun"/** w,'* ]]
+}
+
+# --- Deny-read filename patterns ---
+
+@test "apparmor profile includes deny-read filename pattern from regexes" {
+  run sh -c '
+    _tmpdir="'"$_tmpdir"'"
+    _git_parent_toplevel=""
+    _git_common_dir=""
+    _other_worktrees=""
+    _SANDBOX_ALLOW_WRITE_PATHS=""
+    _SANDBOX_ALLOW_WRITE_LOCK_PATHS=""
+    _SANDBOX_ALLOW_WRITE_FILES=""
+    _SANDBOX_DENY_READ_PATHS=""
+    _SANDBOX_DENY_READ_REGEXES="/\.env\$"
+    _WRAPPER_NAME="claude"
+    _APPARMOR_AVAILABLE=1
+    export PROXY_ENABLED=false
+    _detect_git_worktree() { :; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-apparmor.sh"
+    _load_apparmor_profile() { _APPARMOR_PROFILE_LOADED=1; return 0; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-systemd.sh"
+    _setup_sandbox
+    cat "$_tmpdir/apparmor-profile"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny /**/.env r,"* ]]
+}
+
+# --- Git worktree integration ---
+
+@test "apparmor profile includes git parent toplevel as writable" {
+  _wt_dir=$(mktemp -d)
+  _git_parent_toplevel="$_wt_dir"
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"\"$_wt_dir\"/** rwk,"* ]]
+  rm -rf "$_wt_dir"
+}
+
+@test "apparmor profile denies writes to other worktrees" {
+  _other="$(mktemp -d)"
+  _other_worktrees="$_other"
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _aa=$(get_apparmor)
+  [[ "$_aa" == *"deny \"$_other\"/** w,"* ]]
+  rm -rf "$_other"
+}
+
+# --- systemd integration (AppArmor active) ---
+
+@test "systemd props omit ProtectSystem when AppArmor active" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _props=$(get_props)
+  [[ "$_props" != *"ProtectSystem=strict"* ]]
+}
+
+@test "systemd props omit ProtectHome when AppArmor active" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _props=$(get_props)
+  [[ "$_props" != *"ProtectHome=read-only"* ]]
+}
+
+@test "systemd props omit InaccessiblePaths when AppArmor active" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _props=$(get_props)
+  [[ "$_props" != *"InaccessiblePaths="* ]]
+}
+
+@test "systemd props include AppArmorProfile when AppArmor active" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _props=$(get_props)
+  [[ "$_props" == *"AppArmorProfile=jailrun_"* ]]
+}
+
+@test "systemd props retain non-FS properties when AppArmor active" {
+  run_setup_with_apparmor
+  [ "$status" -eq 0 ]
+  _props=$(get_props)
+  [[ "$_props" == *"NoNewPrivileges=yes"* ]]
+  [[ "$_props" == *"CapabilityBoundingSet="* ]]
+  [[ "$_props" == *"SystemCallFilter=@system-service"* ]]
+  [[ "$_props" == *"ProtectKernelLogs=yes"* ]]
+  [[ "$_props" == *"RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6"* ]]
+}
+
+# --- Fallback (AppArmor load fails) ---
+
+@test "systemd props include ProtectSystem when AppArmor load fails" {
+  run sh -c '
+    _tmpdir="'"$_tmpdir"'"
+    _git_parent_toplevel=""
+    _git_common_dir=""
+    _other_worktrees=""
+    _SANDBOX_ALLOW_WRITE_PATHS=""
+    _SANDBOX_ALLOW_WRITE_LOCK_PATHS=""
+    _SANDBOX_ALLOW_WRITE_FILES=""
+    _SANDBOX_DENY_READ_PATHS=""
+    _WRAPPER_NAME="claude"
+    _APPARMOR_AVAILABLE=1
+    export PROXY_ENABLED=false
+    _detect_git_worktree() { :; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-apparmor.sh"
+    # Override _load to fail (simulates no sudo access)
+    _load_apparmor_profile() { _APPARMOR_PROFILE_LOADED=""; return 1; }
+    . "'"$JAILRUN_LIB"'/platform/sandbox-linux-systemd.sh"
+    _setup_sandbox
+    cat "$_tmpdir/systemd-props"
+  ' 2>/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ProtectSystem=strict"* ]]
+  [[ "$output" == *"ProtectHome=read-only"* ]]
+  [[ "$output" != *"AppArmorProfile="* ]]
+}

--- a/tests/sandbox_profile.bats
+++ b/tests/sandbox_profile.bats
@@ -206,6 +206,59 @@ CONF
   [[ "$output" == *'.claude\.json\.tmp'* ]]
 }
 
+@test "seatbelt profile includes deny-read regex for sandbox_deny_read_names" {
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    export WRAPPER_NAME=claude
+    export XDG_CONFIG_HOME="'"$(mktemp -d)"'"
+    mkdir -p "$XDG_CONFIG_HOME/jailrun"
+    cat > "$XDG_CONFIG_HOME/jailrun/config.toml" <<CONF
+[global]
+allowed_aws_profiles = []
+default_aws_profile = ""
+gh_token_name = "classic"
+sandbox_deny_read_names = [".env"]
+CONF
+    . "$JAILRUN_LIB/config.sh"
+    . "$JAILRUN_LIB/credentials.sh"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _setup_sandbox
+    cat "$_tmpdir/sandbox.sb"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'(regex #"/\.env$")'* ]]
+}
+
+@test "seatbelt profile omits deny-read regex when sandbox_deny_read_names is empty" {
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    export WRAPPER_NAME=claude
+    export XDG_CONFIG_HOME="'"$(mktemp -d)"'"
+    mkdir -p "$XDG_CONFIG_HOME/jailrun"
+    cat > "$XDG_CONFIG_HOME/jailrun/config.toml" <<CONF
+[global]
+allowed_aws_profiles = []
+default_aws_profile = ""
+gh_token_name = "classic"
+CONF
+    . "$JAILRUN_LIB/config.sh"
+    . "$JAILRUN_LIB/credentials.sh"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _setup_sandbox
+    cat "$_tmpdir/sandbox.sb"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'(regex #"/'* ]]
+}
+
 @test "exec.sh contains sandbox-exec and env setup" {
   setup_jailrun_env
 


### PR DESCRIPTION
## Summary
- `sandbox_deny_read_names` 設定キーを追加（例: `["\.env"]`）
- macOS: Seatbelt `(regex ...)` で任意パスの指定ファイル名をブロック
- Linux: AppArmor有効時にファイルシステム制御をAppArmorに移行し `deny /**/.env r,` 等のglobパターンでdeny
- AppArmor無効時は従来のsystemd制御にフォールバック（動作変更なし）
- AppArmorプロファイルは `sudo -n apparmor_parser` でロード/アンロード（非対話型sudo必須）

## 設定例
```toml
[global]
sandbox_deny_read_names = [".env"]
```

## プラットフォーム対応
| | macOS (Seatbelt) | Linux (AppArmor有効) | Linux (AppArmor無効) |
|---|---|---|---|
| パス指定deny | subpath | deny glob | InaccessiblePaths |
| ファイル名deny | regex | deny glob | 非対応（WARN） |
| 非存在パスdeny | OK | OK | スキップ |

## Test plan
- [x] macOS Seatbeltテスト全通過（10件）
- [x] Linux systemdテスト全通過（21件、既存動作維持確認）
- [x] AppArmorテスト全通過（16件新規）
- [x] 全テストスイート100/101通過（1件は既存flakyテスト）