### PR TITLE
サイクル v0.3.0

### DIFF
--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -1,7 +1,7 @@
 # AI-DLC プロジェクト設定
 # 生成日: 2026-03-28
 
-starter_kit_version = "2.3.0"
+starter_kit_version = "2.3.5"
 
 [project]
 name = "jailrun"
@@ -43,6 +43,7 @@ branch_mode = "branch"
 unit_branch_enabled = false
 squash_enabled = false
 merge_method = "ask"
+draft_pr = "ask"
 ai_author_auto_detect = true
 
 [rules.documentation]

--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -43,7 +43,7 @@ branch_mode = "branch"
 unit_branch_enabled = false
 squash_enabled = false
 merge_method = "ask"
-draft_pr = "ask"
+draft_pr = "always"
 ai_author_auto_detect = true
 
 [rules.documentation]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,88 @@
 # Change History
 
+## v0.2.1 — Keychainアクセス制限強化とクラウドクレデンシャルdeny-read拡充 (2026-04-14)
+
+macOS Seatbeltプロファイルで従来全面許可されていたKeychain書き込みを設定駆動で絞り込める仕組み（`keychain_profile`）を追加し、主要クラウド／開発ツールのクレデンシャルパス19件をdeny-readデフォルトへ取り込むことでjailrunの保護範囲を大幅に拡大した。
+
+### Changes
+
+#### Keychain Access
+
+- **制御可否の技術調査**: Seatbelt `keychain-access-*` オペレーションは macOS 26.3 で `unbound variable`（制御不可）と判明。代替として Keychain DB への `file-write*` deny が有効であることを検証
+- **採用戦略の決定**: `keychain-db-regex-write-scope`（`~/Library/Keychains` 書き込みをプロファイル設定で絞り込む）を Unit 003 実装方針として確定
+- **`keychain_profile` 設定の追加**: `config.toml` に `keychain_profile`（`deny` / `read-cache-only` / `allow`、デフォルト `allow`）を新設
+- **バリデーション追加**: `lib/config.py` に `keychain_profile` の許容値バリデーションを追加（不正値は即時エラー）。`lib/config.sh` でも不正値検出時に即座に中断するよう修正
+- **Seatbeltプロファイル分岐**: `lib/sandbox.sh` で `KEYCHAIN_PROFILE` 値に応じ macOS Seatbelt プロファイルの `~/Library/Keychains` 書き込み許可を条件分岐
+
+#### Deny-Read Paths
+
+- **デフォルトdeny-readパスを4→23件に拡充**: `lib/sandbox.sh` の `_SANDBOX_DENY_READ_PATHS` に19パス追加
+- **追加対象**: `~/.config/gcloud`, `~/.azure`, `~/.oci`, `~/.docker`, `~/.kube`, `~/.wrangler`, `~/.config/wrangler`, `~/.fly`, `~/.config/netlify`, `~/.config/vercel`, `~/.config/heroku`, `~/.terraform.d`, `~/.vault-token`, `~/.config/op`, `~/.config/hub`, `~/.config/stripe`, `~/.config/firebase` ほか
+- **Linux反映**: `lib/platform/sandbox-linux-systemd.sh` の `InaccessiblePaths` に同追加パスを反映
+- **存在チェック改善**: Linux側の存在チェックを `[ -d ]` → `[ -e ]` に変更し、ファイル単体パスにも対応
+
+#### Tests
+
+- **deny-readパス検証テスト**: `tests/sandbox_profile.bats` に追加パスの存在確認テストを3件追加
+- **`keychain_profile`モード別テスト**: `tests/sandbox_profile.bats` に `allow` / `deny` / `read-cache-only` の各モードテストを追加（Unit 003 完了時に全8件合格、回帰なし）
+- **Linux InaccessiblePathsテスト**: `tests/sandbox_linux_systemd.bats` に反映テストを追加
+
+#### Documentation
+
+- **architecture.md 更新（Unit 001）**: `docs/architecture.md` の deny-read パス一覧を23パスに拡充
+- **architecture.md 更新（Unit 003）**: `docs/architecture.md` の Keychain セクションを `keychain_profile` 3 モード仕様に更新
+- **README 更新（Operations）**: `README.md` / `docs/README.md` の保護対象一覧を deny-read 23 パスと `keychain_profile` 説明込みに更新
+
+### Compatibility
+
+- `keychain_profile` のデフォルトは `allow` のため、設定未指定時は従来挙動を維持（後方互換）
+- deny-read 追加は macOS（Seatbelt）／Linux（systemd `InaccessiblePaths`）共通で適用。既存の4パス（`~/.aws`, `~/.config/gh`, `~/.gnupg`, `~/.ssh`）は維持
+- `keychain_profile=deny` / `read-cache-only` 時は `~/Library/Keychains` 書き込みが Seatbelt プロファイルから除外される。利用者向け挙動説明は `docs/architecture.md` / `docs/README.md` に記載
+
+## v0.2.0 — サンドボックスプロファイル修正の正式化とdenyログ機能追加 (2026-04-14)
+
+v0.1.0サイクル中にWIPで導入されたサンドボックスプロファイル修正（Keychain書き込み・lockfile・atomic write）を正式化し、Seatbeltによるdenyイベントを自動記録する仕組みを追加した。ドキュメントにプロファイル挙動の説明を加え、Linux側のReadWritePathsもあわせて整備した。
+
+### Changes
+
+#### Sandbox Profile
+
+- **lockfile / atomic write サポート**: `lib/sandbox.sh` に lockfile パス（`.claude.lock`, `.claude.json.lock`）と atomic write regex（`.claude.json.tmp.*`）を追加
+- **macOS Seatbelt 反映**: `lib/platform/sandbox-darwin.sh` の Seatbelt プロファイルに lockfile subpath と atomic write regex を反映
+- **Linux systemd 反映**: `lib/platform/sandbox-linux-systemd.sh` の ReadWritePaths に lockfile ディレクトリを追加
+- **Keychain書き込み許可の正式化**: `~/Library/Keychains` への書き込みを Seatbelt プロファイルで許可（Keychain 経由のトークン保存用途）
+- **Seatbeltエスケープヘルパ追加**: `_seatbelt_escape` をユーティリティとして追加
+- **Linux非対称性コメント追加**: `lib/platform/sandbox-linux-systemd.sh` に Linux 固有の挙動差を示すコメントを追加
+
+#### Deny Log
+
+- **macOS deny ログの自動記録**: `log stream --predicate` ベースで Seatbelt deny イベントを自動記録する仕組みを追加
+- **hook 実装**: `_start_deny_log` / `_stop_deny_log` を `lib/platform/sandbox-darwin.sh` に実装、Linux 側は no-op hook で統一
+- **ログ保存先の固定**: `$TMPDIR/jailrun-seatbelt-<PID>.log` に保存し、EXIT trap でクリーンアップ
+- **デバッグモード連携**: `AGENT_SANDBOX_DEBUG=1` 設定時に deny ログを stderr にも出力
+- **起動失敗時の挙動**: `log stream` 起動失敗時は stderr に警告を出し、jailrun 本体は継続起動
+
+#### Fixes
+
+- **Linux lockdir事前作成の除去**: `lib/platform/sandbox-linux-systemd.sh` から lockdir の事前作成処理を除去（#23）
+- **EXIT trap での tmpdir クリーンアップ**: `lib/sandbox.sh` の EXIT trap が tmpdir クリーンアップを確実に行うよう修正
+
+#### Tests
+
+- **sandbox_deny_log.bats 新規追加**: deny ログの起動・停止・失敗時挙動を検証する bats テストを新設
+- **既存テストの継続通過確認**: Unit 001 完了時に `sandbox_profile.bats` 既存 5 件が通過、Unit 002 完了時に deny ログ含む全 9 件テストが通過することを確認
+
+#### Documentation
+
+- **README.md 更新**: `docs/README.md` に Write Allowances（lockfile / atomic write）と Seatbelt Deny Log セクションを追加
+- **architecture.md 更新**: `docs/architecture.md` に Deny Log データフローと Sandbox Architecture の更新を反映
+
+### Compatibility
+
+- 既存の deny/allow 挙動は変更なし。deny ログは観測のみで、サンドボックス判断には影響しない
+- `log stream` 起動失敗時は jailrun 本体の起動を妨げず、stderr 警告のみで継続
+- Linux 環境の deny ログ機能は no-op（macOS Seatbelt 固有。Linux 向けは将来サイクルで検討）
+
 ## v0.1.0 — コードベース整理・品質向上・ドキュメント整備 (2026-03-28)
 
 既存コードベースを全体的にチェック・整理し、初回リリースに向けてコード品質・テストカバレッジ・ドキュメントの3つの軸で品質を引き上げた。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,36 @@
 # Change History
 
+## v0.3.0 — 現状整理・品質向上・バージョン運用統一 (2026-04-20)
+
+VERSION SoT の確立と bump-version スクリプト導入、HISTORY.md の過去サイクル分補完、v0.3.0 リリース手順ドキュメント新設により、リリース可視性とバージョン運用の統一を達成した。併せて Issue #23（Linux lockdir/proper-lockfile 競合）の論理検証を実施した。
+
+### Changes
+
+#### Investigation
+
+- **Issue #23 の論理検証**: Linux 環境の lockdir 事前作成と `proper-lockfile` の競合について、`mkdir -p` 除去後の挙動を再評価。回帰なしを確認してクローズ判断に至った（Unit 001）
+
+#### Version Management
+
+- **`bin/bump-version` 新設**: POSIX sh 実装で `<version> [--message <text>] [--tag] [--dry-run]` CLI を提供。`bin/jailrun` 内 VERSION 行と `HISTORY.md` 先頭見出しを原子的に更新し、`--tag` 指定時は `git tag vX.Y.Z` を作成。失敗時はバックアップからの自動復元で状態変化ゼロを保証（Unit 002）
+- **VERSION SoT の確立**: `bin/jailrun` 内の `VERSION="x.y.z"` 行を `jailrun --version` の単一 source of truth として確立し、`tests/jailrun.bats` もこの値を期待値として参照するよう整備（Unit 002）
+- **`tests/bump_version.bats` 追加**: 正常系・異常系（バージョン形式違反、重複バージョン、HISTORY.md 形式不正、`--tag` での既存 tag／dirty worktree、`--dry-run` 副作用ゼロなど）および `--message` / stdin 入力制約の網羅テストを追加（Unit 002）
+
+#### Release Documentation
+
+- **HISTORY.md 過去サイクル分の補完**: v0.2.0（サンドボックスプロファイル修正の正式化と deny ログ機能追加）と v0.2.1（Keychain アクセス制限強化とクラウドクレデンシャル deny-read 拡充）のエントリを補完し、新しい順（v0.2.1 → v0.2.0 → v0.1.0）に並び替え。一次情報（`construction_unit*.md` / `operations.md` / merge 差分）にトレース可能な fact のみで構成（Unit 003）
+- **v0.3.0 エントリ先頭挿入**: `bin/bump-version` 本実行（初の実運用）により `bin/jailrun` VERSION を `0.3.0` に更新し、HISTORY.md 先頭に v0.3.0 見出しを自動挿入（Unit 004）
+- **`docs/release.md` 新設**: 新規コントリビューターが 1 人でリリース作業を完結できる 5 章構成（semver 規則、bump-version 利用手順、git tag 運用ポリシー、HISTORY.md エントリガイドライン、リリース後確認項目）のリリース手順書を新設（Unit 004）
+
+#### Tests
+
+- **`tests/jailrun.bats` version 期待値更新**: `"jailrun 0.1.0"` → `"jailrun 0.3.0"` に更新し、VERSION SoT の実運用と整合（Unit 004）
+
+### Compatibility
+
+- `jailrun --version` の参照元を `bin/jailrun` 内の `VERSION` 定数に統一した（Unit 002 `construction_unit02.md` / `bin/jailrun` 差分）
+- `docs/release.md` の新設は既存 `docs/*.md` の構造・内容を変更しない独立ファイル追加のみ（既存 `docs/architecture.md` / `docs/contributing.md` / `docs/github-pat-setup.md` / `docs/README.md` は不変）
+
 ## v0.2.1 — Keychainアクセス制限強化とクラウドクレデンシャルdeny-read拡充 (2026-04-14)
 
 macOS Seatbeltプロファイルで従来全面許可されていたKeychain書き込みを設定駆動で絞り込める仕組み（`keychain_profile`）を追加し、主要クラウド／開発ツールのクレデンシャルパス19件をdeny-readデフォルトへ取り込むことでjailrunの保護範囲を大幅に拡大した。

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -1,0 +1,329 @@
+#!/bin/sh
+# bump-version - update jailrun VERSION SoT, HISTORY.md entry and git tag in one shot.
+#
+# Usage: bump-version <new_version> [--message <text>] [--tag] [--dry-run]
+#
+#   <new_version>  vMAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH (normalized to MAJOR.MINOR.PATCH)
+#   --message      title text for the new HISTORY.md heading (stdin 1 line if omitted)
+#   --tag          create git tag v<normalized> (fails if tag exists or worktree dirty)
+#   --dry-run      print intended diff only, no file writes or git operations.
+
+set -eu
+
+_ARG_VERSION=""
+_ARG_MESSAGE=""
+_ARG_MESSAGE_GIVEN=0
+_ARG_TAG=0
+_ARG_DRY_RUN=0
+
+_BACKUP_BIN_JAILRUN=""
+_BACKUP_HISTORY=""
+
+die() {
+  printf '[bump-version] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: bump-version <new_version> [--message <text>] [--tag] [--dry-run]
+
+Arguments:
+  <new_version>        vMAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH
+
+Options:
+  --message <text>     HISTORY.md heading title (read from stdin if omitted)
+  --tag                create git tag v<normalized> (fails on existing tag or dirty worktree)
+  --dry-run            print diff only, no file writes or git operations
+  --help, -h           show this usage and exit 0
+USAGE
+}
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      --message)
+        shift
+        [ $# -gt 0 ] || die "--message requires a value"
+        _ARG_MESSAGE="$1"
+        _ARG_MESSAGE_GIVEN=1
+        shift
+        ;;
+      --tag)
+        _ARG_TAG=1
+        shift
+        ;;
+      --dry-run)
+        _ARG_DRY_RUN=1
+        shift
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        die "unknown option: $1"
+        ;;
+      *)
+        if [ -z "$_ARG_VERSION" ]; then
+          _ARG_VERSION="$1"
+          shift
+        else
+          die "unexpected extra positional argument: $1"
+        fi
+        ;;
+    esac
+  done
+
+  [ -n "$_ARG_VERSION" ] || { usage >&2; die "missing positional argument <new_version>"; }
+}
+
+validate_semver() {
+  _raw="$1"
+  # POSIX ERE: ^v?[0-9]+\.[0-9]+\.[0-9]+$
+  if ! printf '%s' "$_raw" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
+    die "invalid version format: $_raw (expected vMAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH)"
+  fi
+}
+
+normalize_version() {
+  # strip leading 'v' if any
+  printf '%s' "${1#v}"
+}
+
+resolve_title() {
+  if [ "$_ARG_MESSAGE_GIVEN" -eq 1 ]; then
+    printf '%s' "$_ARG_MESSAGE"
+    return 0
+  fi
+  # read one line from stdin
+  if IFS= read -r _title; then
+    # reject extra lines (multi-line stdin is invalid)
+    if IFS= read -r _extra; then
+      die "stdin title must be a single line (extra line detected)"
+    fi
+    printf '%s' "$_title"
+  else
+    die "--message not provided and stdin is empty"
+  fi
+}
+
+validate_title() {
+  _t="$1"
+  # reject empty or whitespace-only
+  _stripped=$(printf '%s' "$_t" | tr -d '[:space:]')
+  [ -n "$_stripped" ] || die "title must not be empty or whitespace only"
+  # reject embedded newlines (case with a literal newline is POSIX-safe;
+  # $(printf '\n') would be stripped by command substitution and match anything)
+  case "$_t" in
+    *"
+"*) die "title must not contain newline characters" ;;
+  esac
+}
+
+read_current_version() {
+  [ -f bin/jailrun ] || die "bin/jailrun not found in current directory"
+  _line=$(grep -E '^VERSION="[^"]*"$' bin/jailrun || true)
+  [ -n "$_line" ] || die "VERSION line not found in bin/jailrun"
+  _count=$(printf '%s\n' "$_line" | wc -l | tr -d ' ')
+  [ "$_count" = "1" ] || die "multiple VERSION lines found in bin/jailrun"
+  printf '%s' "$_line" | sed -E 's/^VERSION="([^"]*)"$/\1/'
+}
+
+assert_not_duplicate_version() {
+  _current="$1"
+  _new="$2"
+  [ "$_current" != "$_new" ] || die "new version equals current VERSION ($_current); nothing to bump"
+}
+
+assert_history_exists() {
+  [ -f HISTORY.md ] || die "HISTORY.md not found in current directory"
+}
+
+assert_history_well_formed() {
+  _first=$(sed -n '1p' HISTORY.md)
+  [ "$_first" = "# Change History" ] || die "HISTORY.md must start with '# Change History'"
+  _heading=$(grep -E '^## ' HISTORY.md | head -n 1)
+  [ -n "$_heading" ] || die "HISTORY.md has no '## ' heading"
+  # Strict heading pattern: '## vMAJOR.MINOR.PATCH \u2014 <title> (YYYY-MM-DD)'
+  # The em dash (U+2014) is encoded as the literal 3-byte UTF-8 sequence.
+  _em_dash=$(printf '\342\200\224')
+  _pattern='^## v[0-9]+\.[0-9]+\.[0-9]+ '"$_em_dash"' .+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$'
+  if ! printf '%s' "$_heading" | grep -Eq "$_pattern"; then
+    die "HISTORY.md first heading must match '## vMAJOR.MINOR.PATCH \u2014 <title> (YYYY-MM-DD)'"
+  fi
+}
+
+assert_not_duplicate_in_history() {
+  _norm="$1"
+  if grep -Eq "^## v${_norm} " HISTORY.md; then
+    die "HISTORY.md already contains entry for v${_norm}"
+  fi
+}
+
+assert_no_existing_tag() {
+  _norm="$1"
+  _existing=$(git tag --list "v${_norm}")
+  [ -z "$_existing" ] || die "git tag v${_norm} already exists"
+}
+
+assert_clean_worktree() {
+  _status=$(git status --porcelain)
+  [ -z "$_status" ] || die "working tree has uncommitted changes; commit or stash before --tag"
+}
+
+render_dry_run_diff() {
+  _current="$1"
+  _norm="$2"
+  _title="$3"
+  _today="$4"
+  _want_tag="$5"
+
+  printf '[bump-version] (dry-run) VERSION: %s -> %s\n' "$_current" "$_norm"
+  printf '[bump-version] (dry-run) HISTORY.md: would prepend:\n'
+  printf '## v%s \342\200\224 %s (%s)\n\n' "$_norm" "$_title" "$_today"
+  if [ "$_want_tag" -eq 1 ]; then
+    printf '[bump-version] (dry-run) git tag: v%s (would create)\n' "$_norm"
+  fi
+}
+
+backup_files() {
+  # Use mktemp for non-predictable backup paths; umask tightened to owner-only.
+  _old_umask=$(umask)
+  umask 077
+  _BACKUP_BIN_JAILRUN=$(mktemp "${TMPDIR:-/tmp}/bump-version.bin-jailrun.XXXXXX") || {
+    umask "$_old_umask"
+    die "failed to allocate backup path for bin/jailrun"
+  }
+  _BACKUP_HISTORY=$(mktemp "${TMPDIR:-/tmp}/bump-version.history.XXXXXX") || {
+    rm -f "$_BACKUP_BIN_JAILRUN"
+    umask "$_old_umask"
+    die "failed to allocate backup path for HISTORY.md"
+  }
+  umask "$_old_umask"
+  cp -p bin/jailrun "$_BACKUP_BIN_JAILRUN" || die "failed to backup bin/jailrun"
+  cp -p HISTORY.md "$_BACKUP_HISTORY" || {
+    rm -f "$_BACKUP_BIN_JAILRUN"
+    die "failed to backup HISTORY.md"
+  }
+}
+
+restore_from_backup() {
+  # best-effort restore; keep backups on failure
+  if [ -n "$_BACKUP_BIN_JAILRUN" ] && [ -f "$_BACKUP_BIN_JAILRUN" ]; then
+    cp "$_BACKUP_BIN_JAILRUN" bin/jailrun 2>/dev/null || \
+      printf '[bump-version] WARN: failed to restore bin/jailrun; backup kept at %s\n' "$_BACKUP_BIN_JAILRUN" >&2
+  fi
+  if [ -n "$_BACKUP_HISTORY" ] && [ -f "$_BACKUP_HISTORY" ]; then
+    cp "$_BACKUP_HISTORY" HISTORY.md 2>/dev/null || \
+      printf '[bump-version] WARN: failed to restore HISTORY.md; backup kept at %s\n' "$_BACKUP_HISTORY" >&2
+  fi
+}
+
+cleanup_backup() {
+  [ -n "$_BACKUP_BIN_JAILRUN" ] && rm -f "$_BACKUP_BIN_JAILRUN"
+  [ -n "$_BACKUP_HISTORY" ] && rm -f "$_BACKUP_HISTORY"
+  return 0
+}
+
+write_version_line() {
+  _norm="$1"
+  # Seed the temp file with a copy of the target so that executable bits / other
+  # permissions are preserved by the subsequent in-place rewrite + atomic rename.
+  _tmp=$(mktemp "bin/.jailrun.tmp.XXXXXX") || return 1
+  cp -p bin/jailrun "$_tmp" || { rm -f "$_tmp"; return 1; }
+  awk -v ver="$_norm" '
+    /^VERSION="[^"]*"$/ && !done {
+      printf "VERSION=\"%s\"\n", ver
+      done = 1
+      next
+    }
+    { print }
+  ' bin/jailrun > "$_tmp" || { rm -f "$_tmp"; return 1; }
+  mv "$_tmp" bin/jailrun || { rm -f "$_tmp"; return 1; }
+  return 0
+}
+
+prepend_history_entry() {
+  _norm="$1"
+  _title="$2"
+  _today="$3"
+  _tmp=$(mktemp ".HISTORY.md.tmp.XXXXXX") || return 1
+
+  # keep line 1 ("# Change History") and insert the new entry heading + blank line right after
+  {
+    sed -n '1p' HISTORY.md
+    printf '\n## v%s \342\200\224 %s (%s)\n' "$_norm" "$_title" "$_today"
+    sed -n '2,$p' HISTORY.md
+  } > "$_tmp" || { rm -f "$_tmp"; return 1; }
+  mv "$_tmp" HISTORY.md || { rm -f "$_tmp"; return 1; }
+  return 0
+}
+
+create_git_tag() {
+  _norm="$1"
+  git tag "v${_norm}"
+}
+
+main() {
+  parse_args "$@"
+
+  validate_semver "$_ARG_VERSION"
+  _version_norm=$(normalize_version "$_ARG_VERSION")
+
+  _title=$(resolve_title)
+  validate_title "$_title"
+
+  _current=$(read_current_version)
+  assert_not_duplicate_version "$_current" "$_version_norm"
+
+  assert_history_exists
+  assert_history_well_formed
+  assert_not_duplicate_in_history "$_version_norm"
+
+  # git-dependent checks only run for real executions; --dry-run performs no git operations.
+  if [ "$_ARG_TAG" -eq 1 ] && [ "$_ARG_DRY_RUN" -eq 0 ]; then
+    assert_no_existing_tag "$_version_norm"
+    assert_clean_worktree
+  fi
+
+  _today=$(date -u +%Y-%m-%d)
+
+  if [ "$_ARG_DRY_RUN" -eq 1 ]; then
+    render_dry_run_diff "$_current" "$_version_norm" "$_title" "$_today" "$_ARG_TAG"
+    exit 0
+  fi
+
+  backup_files
+
+  if ! write_version_line "$_version_norm"; then
+    restore_from_backup
+    die "failed to update bin/jailrun VERSION line (backup: $_BACKUP_BIN_JAILRUN, $_BACKUP_HISTORY)"
+  fi
+
+  if ! prepend_history_entry "$_version_norm" "$_title" "$_today"; then
+    restore_from_backup
+    die "failed to prepend HISTORY.md entry (backup: $_BACKUP_BIN_JAILRUN, $_BACKUP_HISTORY)"
+  fi
+
+  if [ "$_ARG_TAG" -eq 1 ]; then
+    if ! create_git_tag "$_version_norm"; then
+      restore_from_backup
+      die "failed to create git tag v${_version_norm} (backup: $_BACKUP_BIN_JAILRUN, $_BACKUP_HISTORY)"
+    fi
+  fi
+
+  cleanup_backup
+
+  printf '[bump-version] VERSION: %s -> %s\n' "$_current" "$_version_norm"
+  printf '[bump-version] HISTORY.md: prepended "## v%s \342\200\224 %s (%s)"\n' "$_version_norm" "$_title" "$_today"
+  if [ "$_ARG_TAG" -eq 1 ]; then
+    printf '[bump-version] git tag: v%s created\n' "$_version_norm"
+  fi
+}
+
+main "$@"

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -266,7 +266,18 @@ prepend_history_entry() {
 
 create_git_tag() {
   _norm="$1"
-  git tag "v${_norm}"
+  # Stage and commit the bumped files first so the tag points at release contents (not pre-bump HEAD).
+  git add bin/jailrun HISTORY.md || return 1
+  git commit -m "chore: bump version to v${_norm}" >/dev/null || {
+    git reset HEAD -- bin/jailrun HISTORY.md 2>/dev/null || true
+    return 1
+  }
+  if ! git tag "v${_norm}"; then
+    # Roll back the commit we just created so restore_from_backup can safely restore the worktree.
+    git reset --mixed HEAD~1 2>/dev/null || true
+    return 1
+  fi
+  return 0
 }
 
 main() {

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -11,7 +11,7 @@
 
 set -eu
 
-VERSION="0.1.0"
+VERSION="0.3.0"
 
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -11,6 +11,8 @@
 
 set -eu
 
+VERSION="0.1.0"
+
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {
   _target="$1"
@@ -81,7 +83,7 @@ USAGE
     exit 0
     ;;
   --version|-v)
-    echo "jailrun 0.1.0"
+    echo "jailrun $VERSION"
     exit 0
     ;;
   *)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,203 @@
+# jailrun リリース手順
+
+このドキュメントは jailrun の新規コントリビューターが 1 人でリリース作業を完結できることを目的とする。`bin/bump-version` スクリプトの CLI 契約、バージョン番号の付与ルール、`HISTORY.md` エントリ作成ガイドライン、git tag 運用ポリシー、リリース後の確認項目を順に記す。
+
+## 1. バージョン番号付与ルール（semver）
+
+jailrun は [Semantic Versioning 2.0.0](https://semver.org/lang/ja/) に準拠し、`MAJOR.MINOR.PATCH` 形式でバージョン番号を付与する。昇格基準は以下の通り。
+
+- **MAJOR**: 互換性破壊を伴う変更
+  - 例: `bin/jailrun` の CLI 引数・サブコマンドの非互換な変更、`config.toml` スキーマの後方非互換な変更、サンドボックスプロファイルのデフォルト挙動が既存利用を破壊する変更
+- **MINOR**: 後方互換な機能追加
+  - 例: 新規コマンド・新規設定項目・新規プロファイル・新規 deny-read パスの追加、既存 API の拡張
+- **PATCH**: 後方互換なバグ修正・内部改善
+  - 例: サンドボックスプロファイルの不具合修正、ドキュメント誤字修正、テスト追加
+
+昇格判断時は、当該サイクルの `.aidlc/cycles/vX.Y.Z/requirements/intent.md` と各 Unit 定義の「変更対象」「境界」セクションを確認し、利用者影響を評価する。
+
+## 2. `bin/bump-version` スクリプトの利用手順
+
+`bin/bump-version` は `bin/jailrun` 内の `VERSION` 行と `HISTORY.md` 先頭のエントリ見出しを一括で更新するスクリプト。オプションで `git tag` 作成にも対応する。
+
+### 2.1 CLI シンタックス
+
+```text
+bin/bump-version <new_version> [--message <text>] [--tag] [--dry-run]
+```
+
+### 2.2 引数詳細
+
+| 引数 | 必須 | 説明 |
+|------|------|------|
+| `<new_version>` | 必須 | `vMAJOR.MINOR.PATCH` または `MAJOR.MINOR.PATCH`。内部で `MAJOR.MINOR.PATCH` に正規化される |
+| `--message <text>` | 任意 | HISTORY.md 見出しの **タイトル部** のみを指定する（`## vX.Y.Z — <text> (YYYY-MM-DD)` の `<text>`）。省略時は標準入力から 1 行読み取る |
+| `--tag` | 任意 | 指定時のみ `git tag vX.Y.Z` を作成する。未指定時は tag 作成せず、`bin/jailrun` と `HISTORY.md` のみ更新 |
+| `--dry-run` | 任意 | 変更差分を stdout 表示するのみで、ファイル書き込み・tag 作成を行わない |
+
+### 2.3 タイトル入力の制約
+
+`--message <text>` および標準入力経由で与えるタイトルは以下の制約を満たす必要がある。
+
+- 空文字・空白のみは拒否される
+- 改行文字を含む文字列は拒否される
+- 標準入力経由の場合は 1 行のみ許容（2 行目以降が検出されるとエラー）
+- `--message` を指定した場合、標準入力は読まれない
+
+### 2.4 実行前提
+
+- `bin/jailrun` に `VERSION="..."` 行が 1 つ存在すること
+- `HISTORY.md` が `# Change History` で始まり、最初の `## ` 見出しが `^## v[0-9]+\.[0-9]+\.[0-9]+ — .+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$` に厳格一致すること
+- **clean worktree 要求は `--tag` 指定時かつ `--dry-run` 未指定の本実行時のみ**。それ以外（`--tag` なし、または `--tag --dry-run` の組み合わせ）では dirty worktree を許容する
+
+### 2.5 挙動
+
+- 日付は UTC 日付で書き込まれる（`date -u +%Y-%m-%d`）
+- `bin/bump-version` が自動挿入するのは **見出し行のみ**（`## vX.Y.Z — <タイトル> (YYYY-MM-DD)` + 直後の空行 1 行）。`### Changes` / `### Compatibility` などの本文ブロックは **リリース担当者が手動で追記** する（二段構成）
+- 書き込み段階で失敗した場合は、バックアップ（`bin/jailrun` / `HISTORY.md` の一時コピー）から自動復元される
+
+### 2.6 実行例
+
+```sh
+# 通常の本実行（リリース直前に実施）
+bin/bump-version 0.3.0 --message "現状整理・品質向上・バージョン運用統一"
+
+# 変更内容を確認するだけ（ファイル書き込みなし）
+bin/bump-version 0.3.0 --message "test" --dry-run
+
+# tag も同時に作成（clean worktree 必須）
+bin/bump-version 0.3.0 --message "release" --tag
+```
+
+本サイクル（v0.3.0）のリリースでは `--tag` は指定せず、tag 作成は Operations Phase で PR マージ後に別途行う運用としている（次章参照）。
+
+### 2.7 異常系の挙動
+
+以下の条件で非 0 終了し、ファイル・tag の状態は実行前と同一に保たれる（状態変化ゼロ保証）。
+
+- バージョン形式違反（`abc`、`1.2`、`v1.2.3.4` 等）
+- 既存バージョンと同一値
+- `HISTORY.md` 不在または期待形式不一致
+- 重複見出し（同じ `## vX.Y.Z ...` が既存）
+- `--tag` 指定時に既存 tag が存在する／worktree が dirty
+- `--message` も stdin もない／空／複数行
+
+## 3. git tag 運用ポリシー
+
+### 3.1 tag 付与タイミング
+
+サイクル PR（`cycle/vX.Y.Z` → `main`）が main にマージされた**直後**に、リリース担当者が手動で tag を付与する。
+
+### 3.2 tag 作成コマンド
+
+```sh
+# マージ後、main ブランチに移動してから実行
+git checkout main
+git pull
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+### 3.3 `bin/bump-version --tag` との使い分け
+
+`bin/bump-version --tag` はローカルで tag を作成するが、v0.3.0 時点の運用では **マージ前の Construction Phase では tag を作成せず**、サイクル PR マージ後の Operations Phase でのみ tag を付与する。このため `bin/bump-version` 本実行時は `--tag` を指定しない。
+
+### 3.4 削除・移動の禁止
+
+一度リモート（`origin`）に push した tag は原則として削除・移動しない。誤タグを付与した場合は、新しいバージョン番号で打ち直す運用とする。
+
+### 3.5 tag 命名規則
+
+tag 名は `v<MAJOR.MINOR.PATCH>` 形式（`v` プレフィックス必須）。`bin/bump-version` がこの形式で作成する。
+
+## 4. `HISTORY.md` エントリ作成ガイドライン
+
+### 4.1 見出しフォーマット
+
+```markdown
+## vMAJOR.MINOR.PATCH — <タイトル> (YYYY-MM-DD)
+```
+
+正規表現: `^## v[0-9]+\.[0-9]+\.[0-9]+ — .+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$`
+
+### 4.2 挿入位置
+
+`# Change History` 見出し直下、既存の最新バージョンエントリの直前に新エントリを挿入する。`bin/bump-version` がこの位置で自動挿入する。
+
+### 4.3 タイトル決定規則
+
+`.aidlc/cycles/vX.Y.Z/requirements/intent.md` の冒頭「プロジェクト名」行から `jailrun vX.Y.Z — ` プレフィックスを除去した残りを採用する。
+
+例:
+
+- `jailrun v0.3.0 — 現状整理・品質向上・バージョン運用統一` → `現状整理・品質向上・バージョン運用統一`
+
+### 4.4 本文構造
+
+見出し直下に以下の構造で手動追記する。
+
+```markdown
+## vMAJOR.MINOR.PATCH — <タイトル> (YYYY-MM-DD)
+
+<概要1段落：当該サイクルの主要成果を 3〜5 文でまとめる>
+
+### Changes
+
+#### <カテゴリ名1>
+
+- **<項目名>**: <詳細>
+- **<項目名>**: <詳細>
+
+#### <カテゴリ名2>
+
+- **<項目名>**: <詳細>
+
+### Compatibility
+
+- <互換性情報 1>
+- <互換性情報 2>
+```
+
+### 4.5 Changes セクションのガイドライン
+
+- **カテゴリ名**: サイクルの主要テーマに応じて命名する。既存 HISTORY.md では `Sandbox Profile` / `Keychain Access` / `Deny-Read Paths` / `Documentation` / `Tests` / `Version Management` などを採用
+- **項目数**: 1 カテゴリあたり 1〜6 項目の範囲で許容する。少数項目のカテゴリ（単発のバグ修正など）も許容
+- **一次情報トレース**: 各箇条書きは `.aidlc/cycles/vX.Y.Z/history/construction_unit*.md` / `operations.md` / マージコミット差分のいずれかに根拠を持つ事実のみで構成する。intent.md の「やりたいこと」のような未確定情報は含めない
+
+### 4.6 Compatibility セクションのガイドライン
+
+- **採用可**: `construction_unit*.md` の「実行内容」や `operations.md` に明記された互換性情報、merge 差分から読み取れる不変条件（デフォルト値が後方互換、既存 API の維持、OS 固有機能のスコープ明記など）
+- **採用不可**: intent.md の「制約事項」そのもの（実装予定の制約であり、出荷された挙動とは限らない）、「実装確認」のような曖昧な根拠表現
+
+### 4.7 未完了 Unit の雛形を書かない
+
+Construction Phase の途中で `bin/bump-version` を本実行する場合（本サイクル v0.3.0 の Unit 004 のような運用）、その時点で未完了の Unit に関する Changes 項目を**先出しで書いてはいけない**。未完了 Unit の成果物は確定していないため、先出しすると利用者向けリリースノートに未確定情報が混在する。
+
+この場合の運用:
+
+1. `bin/bump-version` 実行時点では、確定済み Unit の分のみを `### Changes` / `### Compatibility` に記述する
+2. 未完了 Unit 分は、担当 Unit の履歴ファイル（`history/construction_unit{NN}.md`）に「Operations Phase 引き継ぎメモ」として記録する
+3. 後続 Unit 完了後、Operations Phase のリリース準備ステップで該当エントリに追記する
+
+### 4.8 記録不足の扱い
+
+一次情報（`construction_unit*.md` / `operations.md` / マージ差分）および補助情報（intent.md / inception.md / `git log`）のいずれにも該当事実が記載されていない場合のみ「（記録不足）」と明示する。単なる「情報が少ない」「調査に時間がかかる」は該当しない。
+
+## 5. リリース後の確認項目
+
+PR マージおよび tag 付与後、以下を順に確認する。
+
+- [ ] `bin/jailrun --version` が期待値（例: `jailrun 0.3.0`）を返す
+- [ ] `make test` 全件がパスする
+- [ ] `HISTORY.md` の先頭エントリが新バージョンで、`### Changes` / `### Compatibility` が手動補筆済み
+- [ ] `git tag -l v<version>` で tag がローカルに存在する
+- [ ] `git ls-remote --tags origin v<version>` でリモートに tag が反映されている
+- [ ] main ブランチの HEAD が `bin/jailrun` VERSION 更新コミット以降であること
+
+GitHub Releases 機能の利用は本サイクルでは採用していない。将来採用する場合は、tag を元にリリースノートを作成し、`HISTORY.md` エントリ本文を Release description に貼り付ける運用を想定する。
+
+## 関連ドキュメント
+
+- [`docs/architecture.md`](./architecture.md) - jailrun のアーキテクチャ
+- [`docs/contributing.md`](./contributing.md) - コントリビューション手順
+- [`HISTORY.md`](../HISTORY.md) - 過去リリース履歴
+- [`bin/bump-version`](../bin/bump-version) - 本ドキュメントで扱うリリーススクリプト実装

--- a/tests/bump_version.bats
+++ b/tests/bump_version.bats
@@ -105,6 +105,23 @@ assert_no_state_change() {
   [[ "$output" == "v0.2.0" ]]
 }
 
+@test "--tag creates a commit and tag references the bumped contents" {
+  before_head=$(git rev-parse HEAD)
+  before_count=$(git rev-list --count HEAD)
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
+  [ "$status" -eq 0 ]
+  after_head=$(git rev-parse HEAD)
+  after_count=$(git rev-list --count HEAD)
+  # A new commit must have been created so the tag references release contents (not pre-bump HEAD).
+  [ "$before_head" != "$after_head" ]
+  [ "$after_count" -eq $((before_count + 1)) ]
+  # The tag must reference the new HEAD, and the new HEAD must contain the bumped VERSION.
+  tag_ref=$(git rev-list -n1 v0.2.0)
+  [ "$tag_ref" = "$after_head" ]
+  git show "HEAD:bin/jailrun" | grep -qE '^VERSION="0\.2\.0"$'
+  git show "HEAD:HISTORY.md" | grep -q "## v0.2.0"
+}
+
 @test "without --tag no git tag is created" {
   run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
   [ "$status" -eq 0 ]

--- a/tests/bump_version.bats
+++ b/tests/bump_version.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+
+# Tests for bin/bump-version
+#
+# All tests run inside an isolated fixture git repository under BATS_TEST_TMPDIR,
+# so the real repository's .git, working tree, and tags are never touched.
+
+setup() {
+  BUMP_VERSION="$BATS_TEST_DIRNAME/../bin/bump-version"
+  FIXTURE_REPO="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$FIXTURE_REPO/bin"
+  cat > "$FIXTURE_REPO/bin/jailrun" <<'EOF'
+#!/bin/sh
+set -eu
+
+VERSION="0.1.0"
+
+echo "jailrun $VERSION"
+EOF
+  chmod +x "$FIXTURE_REPO/bin/jailrun"
+  printf '# Change History\n\n## v0.0.1 \342\200\224 seed (2020-01-01)\n\nSeed entry.\n' > "$FIXTURE_REPO/HISTORY.md"
+  cd "$FIXTURE_REPO"
+  git init --quiet
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git add bin/jailrun HISTORY.md
+  git commit --quiet -m "seed"
+}
+
+# Snapshot file contents and git tag list. Use inside a test to verify "no state change".
+snapshot_state() {
+  VERSION_BEFORE=$(cat bin/jailrun)
+  HISTORY_BEFORE=$(cat HISTORY.md)
+  TAGS_BEFORE=$(git tag --list)
+  STATUS_BEFORE=$(git status --porcelain)
+}
+
+assert_no_state_change() {
+  [ "$(cat bin/jailrun)" = "$VERSION_BEFORE" ] || { echo "bin/jailrun changed" >&2; return 1; }
+  [ "$(cat HISTORY.md)" = "$HISTORY_BEFORE" ] || { echo "HISTORY.md changed" >&2; return 1; }
+  [ "$(git tag --list)" = "$TAGS_BEFORE" ] || { echo "git tag list changed" >&2; return 1; }
+  [ "$(git status --porcelain)" = "$STATUS_BEFORE" ] || { echo "git status changed" >&2; return 1; }
+}
+
+@test "dry-run outputs diff and does not modify files" {
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(dry-run) VERSION: 0.1.0 -> 0.2.0"* ]]
+  [[ "$output" == *"(dry-run) HISTORY.md"* ]]
+  assert_no_state_change
+}
+
+@test "dry-run --tag succeeds outside a git repository (no git operations)" {
+  # Move the fixture contents to a non-git directory so any git call would fail.
+  NONGIT="$BATS_TEST_TMPDIR/nongit"
+  mkdir -p "$NONGIT/bin"
+  cp -p bin/jailrun "$NONGIT/bin/jailrun"
+  cp -p HISTORY.md "$NONGIT/HISTORY.md"
+  cd "$NONGIT"
+  [ ! -d .git ]
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(would create)"* ]]
+  # Nothing should have been written.
+  grep -qE '^VERSION="0\.1\.0"$' bin/jailrun
+}
+
+@test "bin/jailrun retains executable permission after bump" {
+  before_perm=$(ls -l bin/jailrun | awk '{print $1}')
+  [[ "$before_perm" == *x* ]]
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 0 ]
+  after_perm=$(ls -l bin/jailrun | awk '{print $1}')
+  [[ "$after_perm" == *x* ]]
+  [ -x bin/jailrun ]
+}
+
+@test "normal run with MAJOR.MINOR.PATCH updates VERSION and HISTORY.md" {
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 0 ]
+  grep -qE '^VERSION="0\.2\.0"$' bin/jailrun
+  # HISTORY.md second line should be blank, third line should be new entry
+  head -n 3 HISTORY.md | tail -n 1 | grep -q "0.2.0"
+  head -n 3 HISTORY.md | tail -n 1 | grep -q "Release 0.2.0"
+}
+
+@test "v-prefixed version is normalized identically to bare version" {
+  run "$BUMP_VERSION" v0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 0 ]
+  grep -qE '^VERSION="0\.2\.0"$' bin/jailrun
+  grep -qE '^## v0\.2\.0 ' HISTORY.md
+}
+
+@test "title can be provided via stdin when --message is omitted" {
+  run sh -c "echo 'Release via stdin' | '$BUMP_VERSION' 0.2.0"
+  [ "$status" -eq 0 ]
+  grep -q "Release via stdin" HISTORY.md
+}
+
+@test "--tag creates git tag v<version>" {
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
+  [ "$status" -eq 0 ]
+  run git tag --list "v0.2.0"
+  [[ "$output" == "v0.2.0" ]]
+}
+
+@test "without --tag no git tag is created" {
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 0 ]
+  run git tag --list
+  [[ "$output" != *"v0.2.0"* ]]
+}
+
+@test "invalid version format exits 1 with no state change" {
+  for bad in abc 1.2 v1.2.3.4; do
+    snapshot_state
+    run "$BUMP_VERSION" "$bad" --message "oops"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"invalid version format"* ]]
+    assert_no_state_change
+  done
+}
+
+@test "duplicate version (equals current) exits 1 with no state change" {
+  snapshot_state
+  run "$BUMP_VERSION" 0.1.0 --message "same"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"nothing to bump"* ]]
+  assert_no_state_change
+}
+
+@test "existing git tag causes failure and no file change" {
+  git tag v0.2.0
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already exists"* ]]
+  assert_no_state_change
+}
+
+@test "malformed HISTORY.md exits 1 with no state change" {
+  printf 'not a change log\n\n## v0.0.1 seed\n' > HISTORY.md
+  git add HISTORY.md
+  git commit --quiet -m "break history"
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Change History"* ]]
+  assert_no_state_change
+}
+
+@test "HISTORY.md first heading with incomplete format exits 1 with no state change" {
+  # Heading has the vX.Y.Z prefix but no em-dash title or date trailer.
+  printf '# Change History\n\n## v0.0.1\n' > HISTORY.md
+  git add HISTORY.md
+  git commit --quiet -m "incomplete heading"
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must match"* ]]
+  assert_no_state_change
+}
+
+@test "HISTORY.md already contains the target version heading exits 1 with no state change" {
+  # Prepend a canonical v0.2.0 heading so that bump of 0.2.0 should collide.
+  printf '# Change History\n\n## v0.2.0 \342\200\224 already released (2026-01-01)\n\n## v0.0.1 \342\200\224 seed (2020-01-01)\n' > HISTORY.md
+  # Bump current VERSION so version-equality check does not short-circuit first.
+  sed -i.bak 's/VERSION="0.1.0"/VERSION="0.0.9"/' bin/jailrun
+  rm -f bin/jailrun.bak
+  git add bin/jailrun HISTORY.md
+  git commit --quiet -m "seed with existing v0.2.0 entry"
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already contains entry for v0.2.0"* ]]
+  assert_no_state_change
+}
+
+@test "missing HISTORY.md exits 1 and bin/jailrun untouched" {
+  rm HISTORY.md
+  git add -A
+  git commit --quiet -m "remove history"
+  VERSION_BEFORE=$(cat bin/jailrun)
+  TAGS_BEFORE=$(git tag --list)
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"HISTORY.md not found"* ]]
+  [ "$(cat bin/jailrun)" = "$VERSION_BEFORE" ]
+  [ "$(git tag --list)" = "$TAGS_BEFORE" ]
+}
+
+@test "missing message and empty stdin exits 1 with no state change" {
+  snapshot_state
+  run sh -c "'$BUMP_VERSION' 0.2.0 < /dev/null"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"stdin is empty"* ]]
+  assert_no_state_change
+}
+
+@test "multi-line --message is rejected" {
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "first line
+second line"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"newline"* ]]
+  assert_no_state_change
+}
+
+@test "dirty worktree blocks --tag with no state change" {
+  echo "# noise" >> README_noise.md
+  snapshot_state
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"uncommitted changes"* ]]
+  assert_no_state_change
+}

--- a/tests/jailrun.bats
+++ b/tests/jailrun.bats
@@ -9,7 +9,7 @@
 @test "jailrun --version shows version" {
   run bin/jailrun --version
   [ "$status" -eq 0 ]
-  [[ "$output" == "jailrun 0.1.0" ]]
+  [[ "$output" == "jailrun 0.3.0" ]]
 }
 
 @test "jailrun with unknown command exits 1" {

--- a/tests/jailrun.bats
+++ b/tests/jailrun.bats
@@ -9,7 +9,9 @@
 @test "jailrun --version shows version" {
   run bin/jailrun --version
   [ "$status" -eq 0 ]
-  [[ "$output" == "jailrun 0.3.0" ]]
+  expected_version="$(grep -E '^VERSION="[^"]*"$' bin/jailrun | sed -E 's/^VERSION="([^"]*)"$/\1/')"
+  [ -n "$expected_version" ]
+  [[ "$output" == "jailrun ${expected_version}" ]]
 }
 
 @test "jailrun with unknown command exits 1" {

--- a/tests/posix_compliance.bats
+++ b/tests/posix_compliance.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "all scripts pass sh -n syntax check" {
-  for f in bin/jailrun lib/*.sh lib/platform/*.sh lib/shims/codex; do
+  for f in bin/jailrun bin/bump-version lib/*.sh lib/platform/*.sh lib/shims/codex; do
     run sh -n "$f"
     if [ "$status" -ne 0 ]; then
       echo "FAIL: $f" >&2
@@ -12,7 +12,7 @@
 }
 
 @test "no scripts have #!/bin/zsh shebang" {
-  for f in bin/jailrun lib/*.sh lib/platform/*.sh lib/shims/codex; do
+  for f in bin/jailrun bin/bump-version lib/*.sh lib/platform/*.sh lib/shims/codex; do
     run head -1 "$f"
     [[ "$output" != *"/bin/zsh"* ]]
   done
@@ -20,14 +20,14 @@
 
 @test "no scripts use zsh-only [[ ]] syntax" {
   # Grep for [[ that isn't in a comment or string
-  for f in bin/jailrun lib/*.sh lib/platform/*.sh lib/shims/codex; do
+  for f in bin/jailrun bin/bump-version lib/*.sh lib/platform/*.sh lib/shims/codex; do
     run grep -n '^\s*\[\[' "$f"
     [ "$status" -ne 0 ]  # grep should find nothing
   done
 }
 
 @test "no scripts contain Japanese characters" {
-  for f in bin/jailrun lib/*.sh lib/platform/*.sh lib/shims/codex; do
+  for f in bin/jailrun bin/bump-version lib/*.sh lib/platform/*.sh lib/shims/codex; do
     count=$(grep -cP '[\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}]' "$f" 2>/dev/null || echo 0)
     if [ "$count" -gt 0 ]; then
       echo "FAIL: $f contains $count lines with Japanese" >&2


### PR DESCRIPTION
## サイクル概要

jailrun v0.3.0 — 現状整理・品質向上・バージョン運用統一サイクル。Issue #23 の論理検証、AI-DLC 2.3.5 取込、jailrun本体バージョン運用統一（VERSION SoT・bump-version スクリプト）、コードベース全体の調査レポート作成を扱う。

## 含まれるUnit

- Unit 001: Issue #23 論理検証と整理
- Unit 002: バージョン SoT 確立と bump-version スクリプト作成
- Unit 003: HISTORY.md 過去サイクル分の補完
- Unit 004: v0.3.0 リリース更新とリリース手順ドキュメント
- Unit 005: AI-DLC 2.3.5 取込確認
- Unit 006: コードベース調査レポート作成
- Unit 007: 既存機能影響確認とリリース手順 dry-run 検証
- Unit 008: コード調査レポートのユーザーレビューと候補確定

## Closes

- Closes #23
