### PR TITLE
サイクル v0.3.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,38 @@
 # Change History
 
+## v0.3.1 — テスト基盤補強・5 領域の回帰保護を確立 (2026-04-23)
+
+v0.3.0 のコードベース調査で特定されたテストカバレッジ不足 5 領域を全て解消。bats（token/ruleset/aws）と Python unittest（config_cli/config_migrate）を組み合わせ、本体コード無変更で品質補強リリースを届けた。
+
+### Changes
+
+#### Tests
+
+- **`tests/token.bats` 新設**: `lib/token.sh` の `_cmd_add` / `_cmd_rotate` / `_cmd_delete` / `_cmd_list` に対する 19 ケースの bats テストを追加。macOS `security` / Linux `secret-tool` の PATH shim による Keychain 呼び出し検証、正常系 / Keychain 未設定 / 不正引数を網羅（Unit 001, Issue #41）
+- **`tests/ruleset.bats` 新設**: `lib/ruleset.sh` の GitHub API 呼び出し（`gh api` 経由のブランチ / タグ保護 apply 系）に対する 19 ケースの bats テストを追加。sysbin ホワイトリスト方式（6 コマンド）で PATH 隔離し、TSV 6 列（category / last 切替）で branch / tag POST を区別。idempotent skip、`gh api` 失敗系、delete 代替の idempotent skip、タグ保護 POST 失敗（RSF1 代表）を網羅（Unit 002, Issue #42）
+- **`tests/aws.bats` 新設**: `lib/aws.sh` の `_setup_aws_credentials` / `_write_aws_profile` に対する 9 ケース（AW1-AW9）の bats テストを追加。`aws configure export-credentials` と `jq` の PATH shim、INI 書き込みの section 重複・順序・行位置検証 helper（14 種）、AWS 失敗時 fail-open、jq 不在 fallback、プロファイル名正規化（`tr 'a-z' 'A-Z' | sed 's/[^A-Z0-9_]/_/g'` で `[A-Z0-9_]` へ閉じた正規化）を網羅（Unit 003, Issue #43）
+- **`tests/test_config_cli.py` 新設**: `lib/config_cli.py` の 6 関数（`cmd_load` / `cmd_show` / `cmd_set` / `cmd_edit` / `cmd_path` / `cmd_init`）に対する 21 ケース（CL1-CL3 / CS1-CS2 / CSET1-CSET9 / CE1-CE3 / CP1 / CI1-CI3）の Python unittest を追加。`config_cli.config_file` + `config.config_file` 両 patch、`os.execvp` スタブ化、`--append` 重複値の no-op 分岐を `set_key_in_toml` spy で直接観測、`--dir` longest-prefix + list append の識別 fixture を網羅（Unit 004, Issue #44）
+- **`tests/test_config_migrate.py` 新設**: `lib/config_migrate.py` の `migrate_shell_to_toml` / `cmd_migrate` 2 関数に対する 12 ケース（MST1-MST8 / CM1-CM4）の Python unittest を追加。`assertEqual` による TOML 全文厳密比較でラウンドトリップを検証、`GH_TOKEN_NAME` の precedence 分岐（`lib/config_migrate.py:54-56`）固定、`FileNotFoundError` / `SystemExit(1)` / `--force` 上書きを網羅（Unit 005, Issue #45）
+
+#### Test Helpers
+
+- **`tests/helpers.bash` 拡充**: token / ruleset / aws テスト向けの共通 helper を追加。PATH shim セットアップ（sysbin ホワイトリスト 12 コマンド: `readlink` / `dirname` / `cat` / `grep` / `cut` / `rm` / `chmod` / `mkdir` / `touch` / `awk` / `tr` / `sed`）、TSV 6 列 shim 呼び出しログ、INI section / key assertion（14 種、section_count / section_order / line_in_nth 系統）、AWS shim 専用のプロファイル名正規化を整備（Unit 001-003）
+
+#### Documentation
+
+- **`docs/contributing.md` Test Structure 更新**: v0.3.1 で追加された 5 テストファイル（`token.bats` / `ruleset.bats` / `aws.bats` / `test_config_cli.py` / `test_config_migrate.py`）を反映。あわせて既存の誤記（実在しない `lint.bats` の削除）と既存欠落ファイル（`bump_version.bats` / `path_resolution.bats` / `posix_compliance.bats` / `sandbox_deny_log.bats` / `sandbox_linux_apparmor.bats` / `shim.bats`）を追記して `tests/` 実在ファイル一覧と全面再同期（Unit 006）
+
+#### Version Management
+
+- **`bin/jailrun` VERSION 更新**: `0.3.0` → `0.3.1`（`bin/bump-version 0.3.1 --message "テスト基盤補強・5 領域の回帰保護を確立"` 経由で `bin/jailrun` VERSION 行と `HISTORY.md` 先頭見出しを同時更新、Unit 006）
+
+### Compatibility
+
+- 本サイクルの変更は **テスト追加 + リリースメタデータ / 文書更新のみ**で、本体コード（`lib/token.sh` / `lib/ruleset.sh` / `lib/aws.sh` / `lib/config_cli.py` / `lib/config_migrate.py` / `lib/config.py` / `bin/jailrun` のロジック部）に変更はない
+- 既存 bats 120 ケース + Python unittest 26 ケース（`tests/test_proxy.py`）は全て引き続きパス
+- 新規 bats 47 ケース（`token.bats` 19 / `ruleset.bats` 19 / `aws.bats` 9）+ Python unittest 33 ケース（`test_config_cli.py` 21 + `test_config_migrate.py` 12）を追加、合計 **bats 167 ケース + Python unittest 59 ケース**
+- `jailrun --version` 出力が `jailrun 0.3.1` に更新される
+
 ## v0.3.0 — 現状整理・品質向上・バージョン運用統一 (2026-04-20)
 
 VERSION SoT の確立と bump-version スクリプト導入、HISTORY.md の過去サイクル分補完、v0.3.0 リリース手順ドキュメント新設により、リリース可視性とバージョン運用の統一を達成した。併せて Issue #23（Linux lockdir/proper-lockfile 競合）の論理検証を実施した。

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -11,7 +11,7 @@
 
 set -eu
 
-VERSION="0.3.0"
+VERSION="0.3.1"
 
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,17 +42,27 @@ python3 -m unittest tests/test_proxy.py -v
 
 ```
 tests/
-├── helpers.bash               Common test helpers
-├── jailrun.bats               CLI entrypoint tests
-├── codex_args.bats            Codex argument rewriting tests
-├── config.bats                Config loading/migration tests
-├── config_cmd.bats            Config CLI subcommand tests
-├── sandbox_linux_systemd.bats systemd property generation tests
-├── credential_guard.bats      Double-sandbox prevention tests
-├── sandbox_profile.bats       Seatbelt profile generation tests
-├── passthrough_env.bats       Environment variable passthrough tests
-├── lint.bats                  Shell script linting checks
-└── test_proxy.py              Proxy unit tests (Python unittest)
+├── helpers.bash                 Common test helpers (PATH shims, INI assertions, etc.)
+├── aws.bats                     AWS credential setup tests (_setup_aws_credentials / _write_aws_profile)
+├── bump_version.bats            bin/bump-version script tests
+├── codex_args.bats              Codex argument rewriting tests
+├── config.bats                  Config loading/migration tests
+├── config_cmd.bats              Config CLI subcommand tests
+├── credential_guard.bats        Double-sandbox prevention tests
+├── jailrun.bats                 CLI entrypoint tests
+├── passthrough_env.bats         Environment variable passthrough tests
+├── path_resolution.bats         Path resolution tests
+├── posix_compliance.bats        POSIX shell compliance checks
+├── ruleset.bats                 GitHub API ruleset (branch/tag protection) tests
+├── sandbox_deny_log.bats        Sandbox deny log tests
+├── sandbox_linux_apparmor.bats  AppArmor profile tests (Linux)
+├── sandbox_linux_systemd.bats   systemd property generation tests (Linux)
+├── sandbox_profile.bats         Seatbelt profile generation tests (macOS)
+├── shim.bats                    Jailrun shim tests
+├── token.bats                   Keychain token management tests (_cmd_add / rotate / delete / list)
+├── test_config_cli.py           config_cli.py unit tests (Python unittest)
+├── test_config_migrate.py       config_migrate.py unit tests (Python unittest)
+└── test_proxy.py                proxy.py unit tests (Python unittest)
 ```
 
 ### Writing Tests

--- a/tests/aws.bats
+++ b/tests/aws.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+# Unit 003: tests/aws.bats — lib/aws.sh bats tests
+#
+# Spec: .aidlc/cycles/v0.3.1/plans/unit-003-plan.md
+# Design: .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/
+#         unit_003_aws_bats_tests_logical_design.md
+#
+# Covers _setup_aws_credentials and _write_aws_profile with aws PATH shim.
+# Real aws CLI and AWS STS are never reached (PATH fixed to shim-bin:sysbin).
+
+load helpers
+
+_aws_preflight() {
+  setup_jailrun_env
+  export _WRAPPER_NAME=jailrun
+  export _DEFAULT_REGION=us-east-1
+  export DEFAULT_AWS_PROFILE=default
+  export ALLOWED_AWS_PROFILES=""
+  unset AGENT_AWS_PROFILES
+  unset MOCK_AWS_EXPORT_STATE_DEFAULT MOCK_AWS_EXPORT_JSON_DEFAULT MOCK_AWS_REGION_DEFAULT
+  unset MOCK_AWS_EXPORT_STATE_WORK MOCK_AWS_EXPORT_JSON_WORK MOCK_AWS_REGION_WORK
+  unset MOCK_AWS_EXPORT_STATE_PROD MOCK_AWS_EXPORT_JSON_PROD MOCK_AWS_REGION_PROD
+}
+
+_aws_source() {
+  # shellcheck disable=SC1091
+  . "$JAILRUN_LIB/aws.sh"
+}
+
+_JSON_OK_DEFAULT='{"AccessKeyId":"AKIATESTKEY","SecretAccessKey":"secrettestvalue","SessionToken":"sessiontokentest","Expiration":"2026-01-01T00:00:00Z"}'
+_JSON_NO_TOKEN='{"AccessKeyId":"AKIATESTKEY","SecretAccessKey":"secrettestvalue","SessionToken":"","Expiration":"2026-01-01T00:00:00Z"}'
+_JSON_WORK='{"AccessKeyId":"WORKKEY","SecretAccessKey":"WORKSECRET","SessionToken":"WORKTOKEN","Expiration":"2026-01-01T00:00:00Z"}'
+_JSON_DEFAULT_AK1='{"AccessKeyId":"AK1","SecretAccessKey":"SK1","SessionToken":"ST1","Expiration":"2026-01-01T00:00:00Z"}'
+_JSON_WORK_AK2='{"AccessKeyId":"AK2","SecretAccessKey":"SK2","SessionToken":"ST2","Expiration":"2026-01-01T00:00:00Z"}'
+_JSON_PROD_AK3='{"AccessKeyId":"AK3","SecretAccessKey":"SK3","SessionToken":"ST3","Expiration":"2026-01-01T00:00:00Z"}'
+
+@test "AW1 single default profile 正常系 (session_token あり、jq 有無非依存)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export MOCK_AWS_EXPORT_STATE_DEFAULT=ok
+  export MOCK_AWS_EXPORT_JSON_DEFAULT="$_JSON_OK_DEFAULT"
+  export MOCK_AWS_REGION_DEFAULT=us-east-1
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AWS: default (temporary credentials)"* ]]
+
+  assert_aws_configure_called export-credentials default
+  assert_aws_configure_called get-region default
+
+  assert_aws_config_section_count default 1
+  assert_aws_config_section_count "profile default" 1
+  assert_aws_config_section_order default "profile default"
+  assert_aws_config_line default region us-east-1
+  assert_aws_config_line "profile default" region us-east-1
+
+  assert_aws_creds_section_count default 2
+  assert_aws_creds_section_order default default
+  assert_aws_creds_line_in_nth default 1 aws_access_key_id AKIATESTKEY
+  assert_aws_creds_line_in_nth default 1 aws_secret_access_key secrettestvalue
+  assert_aws_creds_line_in_nth default 1 aws_session_token sessiontokentest
+  assert_aws_creds_line_in_nth default 2 aws_access_key_id AKIATESTKEY
+  assert_aws_creds_line_in_nth default 2 aws_secret_access_key secrettestvalue
+  assert_aws_creds_line_in_nth default 2 aws_session_token sessiontokentest
+}
+
+@test "AW2 session_token なし (aws_session_token 行が省略される)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export MOCK_AWS_EXPORT_STATE_DEFAULT=ok
+  export MOCK_AWS_EXPORT_JSON_DEFAULT="$_JSON_NO_TOKEN"
+  export MOCK_AWS_REGION_DEFAULT=us-east-1
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  assert_aws_creds_section default
+  assert_aws_creds_line default aws_access_key_id AKIATESTKEY
+  assert_aws_creds_line default aws_secret_access_key secrettestvalue
+  assert_aws_creds_line_absent default aws_session_token
+}
+
+@test "AW3 AGENT_AWS_PROFILES override (default セクションに override 先 credentials)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export AGENT_AWS_PROFILES=work
+  export MOCK_AWS_EXPORT_STATE_WORK=ok
+  export MOCK_AWS_EXPORT_JSON_WORK="$_JSON_WORK"
+  export MOCK_AWS_REGION_WORK=ap-northeast-1
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  assert_aws_configure_called export-credentials work
+  assert_aws_configure_not_called export-credentials default
+
+  # config: [default] once, [profile work] once, no [profile default]
+  assert_aws_config_section_count default 1
+  assert_aws_config_section_count "profile work" 1
+  assert_aws_config_section_not_exists "profile default"
+  assert_aws_config_section_order default "profile work"
+  assert_aws_config_line default region ap-northeast-1
+  assert_aws_config_line "profile work" region ap-northeast-1
+
+  # creds: [default] once (work credentials), [work] once
+  assert_aws_creds_section_count default 1
+  assert_aws_creds_section_count work 1
+  assert_aws_creds_section_order default work
+  assert_aws_creds_line default aws_access_key_id WORKKEY
+  assert_aws_creds_line default aws_secret_access_key WORKSECRET
+  assert_aws_creds_line default aws_session_token WORKTOKEN
+  assert_aws_creds_line work aws_access_key_id WORKKEY
+  assert_aws_creds_line work aws_secret_access_key WORKSECRET
+}
+
+@test "AW4 複数プロファイル (default + work、書き込み順序と default 重複を固定)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export AGENT_AWS_PROFILES="default work"
+  export MOCK_AWS_EXPORT_STATE_DEFAULT=ok
+  export MOCK_AWS_EXPORT_JSON_DEFAULT="$_JSON_DEFAULT_AK1"
+  export MOCK_AWS_REGION_DEFAULT=us-east-1
+  export MOCK_AWS_EXPORT_STATE_WORK=ok
+  export MOCK_AWS_EXPORT_JSON_WORK="$_JSON_WORK_AK2"
+  export MOCK_AWS_REGION_WORK=ap-northeast-1
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  assert_aws_configure_called export-credentials default
+  assert_aws_configure_called export-credentials work
+
+  assert_aws_config_section_count default 1
+  assert_aws_config_section_count "profile default" 1
+  assert_aws_config_section_count "profile work" 1
+  assert_aws_config_section_order default "profile default" "profile work"
+  assert_aws_config_line default region us-east-1
+  assert_aws_config_line "profile default" region us-east-1
+  assert_aws_config_line "profile work" region ap-northeast-1
+
+  assert_aws_creds_section_count default 2
+  assert_aws_creds_section_count work 1
+  assert_aws_creds_section_order default default work
+  assert_aws_creds_line_in_nth default 1 aws_access_key_id AK1
+  assert_aws_creds_line_in_nth default 1 aws_secret_access_key SK1
+  assert_aws_creds_line_in_nth default 2 aws_access_key_id AK1
+  assert_aws_creds_line_in_nth default 2 aws_secret_access_key SK1
+  assert_aws_creds_line work aws_access_key_id AK2
+  assert_aws_creds_line work aws_secret_access_key SK2
+}
+
+@test "AW5 allow list フィルタ (prod は除外され work のみ処理)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export ALLOWED_AWS_PROFILES=work
+  export AGENT_AWS_PROFILES="work prod"
+  export MOCK_AWS_EXPORT_STATE_WORK=ok
+  export MOCK_AWS_EXPORT_JSON_WORK="$_JSON_WORK_AK2"
+  export MOCK_AWS_REGION_WORK=ap-northeast-1
+  export MOCK_AWS_EXPORT_STATE_PROD=ok
+  export MOCK_AWS_EXPORT_JSON_PROD="$_JSON_PROD_AK3"
+  export MOCK_AWS_REGION_PROD=us-west-2
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AWS profile 'prod' is not in the allow list"* ]]
+
+  assert_aws_configure_called export-credentials work
+  assert_aws_configure_not_called export-credentials prod
+
+  assert_aws_creds_section work
+  assert_aws_creds_section_not_exists prod
+  assert_aws_config_section_not_exists "profile prod"
+}
+
+@test "AW6 異常系 aws configure export-credentials 失敗 (fail-open: WARN + セクション未書き込み)" {
+  _aws_preflight
+  setup_aws_shims
+
+  export AGENT_AWS_PROFILES=default
+  export MOCK_AWS_EXPORT_STATE_DEFAULT=fail
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"failed to retrieve credentials for AWS profile 'default' (need aws sso login?)"* ]]
+
+  assert_aws_configure_called export-credentials default
+  assert_aws_configure_not_called get-region default
+
+  assert_aws_config_section_not_exists default
+  assert_aws_config_section_not_exists "profile default"
+  assert_aws_creds_section_not_exists default
+}
+
+@test "AW7 aws 未インストール (shim 削除、空ファイルのまま関数終了)" {
+  _aws_preflight
+  setup_aws_shims
+
+  rm -f "$BATS_TEST_TMPDIR/shim-bin/aws"
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+
+  # Both files exist (touched in aws.sh head) but have zero section lines
+  [ -f "$_aws_config" ]
+  [ -f "$_aws_creds" ]
+  _config_sections=$(grep -c '^\[' "$_aws_config" || true)
+  _creds_sections=$(grep -c '^\[' "$_aws_creds" || true)
+  [ "$_config_sections" = "0" ]
+  [ "$_creds_sections" = "0" ]
+
+  assert_aws_configure_not_called export-credentials default
+}
+
+@test "AW8 _write_aws_profile 単体 (session_token 空文字時の省略)" {
+  _aws_preflight
+  setup_aws_shims
+
+  _aws_source
+
+  _write_aws_profile "myprof" "myprof" "AK" "SK" "" "ap-northeast-1"
+
+  assert_aws_config_section myprof
+  assert_aws_config_line myprof region ap-northeast-1
+  assert_aws_creds_section myprof
+  assert_aws_creds_line myprof aws_access_key_id AK
+  assert_aws_creds_line myprof aws_secret_access_key SK
+  assert_aws_creds_line_absent myprof aws_session_token
+}
+
+@test "AW9 jq 不在経路 (grep/cut fallback、AW1 と同値結果)" {
+  _aws_preflight
+  setup_aws_shims_without_jq
+
+  export MOCK_AWS_EXPORT_STATE_DEFAULT=ok
+  export MOCK_AWS_EXPORT_JSON_DEFAULT="$_JSON_OK_DEFAULT"
+  export MOCK_AWS_REGION_DEFAULT=us-east-1
+
+  _aws_source
+  run _setup_aws_credentials
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AWS: default (temporary credentials)"* ]]
+
+  assert_aws_configure_called export-credentials default
+  assert_aws_configure_called get-region default
+
+  assert_aws_config_section_count default 1
+  assert_aws_config_section_count "profile default" 1
+  assert_aws_config_section_order default "profile default"
+  assert_aws_config_line default region us-east-1
+  assert_aws_config_line "profile default" region us-east-1
+
+  assert_aws_creds_section_count default 2
+  assert_aws_creds_section_order default default
+  assert_aws_creds_line_in_nth default 1 aws_access_key_id AKIATESTKEY
+  assert_aws_creds_line_in_nth default 1 aws_secret_access_key secrettestvalue
+  assert_aws_creds_line_in_nth default 1 aws_session_token sessiontokentest
+  assert_aws_creds_line_in_nth default 2 aws_access_key_id AKIATESTKEY
+  assert_aws_creds_line_in_nth default 2 aws_secret_access_key secrettestvalue
+  assert_aws_creds_line_in_nth default 2 aws_session_token sessiontokentest
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -571,3 +571,364 @@ assert_gh_payload_contains() {
   cat "$SHIM_CALLS_LOG" >&2
   return 1
 }
+
+# ----------------------------------------------------------------
+# Unit 003 (aws.bats) helpers — aws PATH shim + sysbin whitelist
+#
+# Spec: .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/
+#       unit_003_aws_bats_tests_logical_design.md
+#
+# PATH is strongly isolated to $BATS_TEST_TMPDIR/shim-bin:$BATS_TEST_TMPDIR/sysbin
+# (no /usr/bin, no /bin). sysbin holds mandatory symlinks (12 commands: readlink
+# dirname cat grep cut rm chmod mkdir touch awk tr sed; the last two are used
+# for closed profile-name normalization in the aws shim) plus an optional jq
+# symlink (present only if OS jq is available). The aws binary is NEVER added
+# to sysbin to guarantee that real aws CLI is unreachable.
+#
+# shim-calls.log is a 6-column TSV:
+#   command<TAB>category<TAB>method<TAB>argv<TAB>profile<TAB>exit_code
+#
+# Test flow: set pre-source env vars -> setup_aws_shims -> source lib/aws.sh
+# (which touches $_tmpdir/aws-config and $_tmpdir/aws-credentials) -> run
+# _setup_aws_credentials or call _write_aws_profile directly.
+# ----------------------------------------------------------------
+
+setup_aws_shims() {
+  mkdir -p "$BATS_TEST_TMPDIR/shim-bin"
+  mkdir -p "$BATS_TEST_TMPDIR/sysbin"
+  mkdir -p "$BATS_TEST_TMPDIR/home"
+  mkdir -p "$BATS_TEST_TMPDIR/aws-work"
+
+  _aws_link_sysbin_whitelist || return 1
+  _aws_link_jq_optional
+
+  _write_aws_shim
+
+  chmod +x "$BATS_TEST_TMPDIR/shim-bin"/*
+
+  export PATH="$BATS_TEST_TMPDIR/shim-bin:$BATS_TEST_TMPDIR/sysbin"
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  export USER="jailrun-test"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export SHIM_CALLS_LOG="$BATS_TEST_TMPDIR/shim-calls.log"
+  export _tmpdir="$BATS_TEST_TMPDIR/aws-work"
+
+  : > "$SHIM_CALLS_LOG"
+}
+
+setup_aws_shims_without_jq() {
+  setup_aws_shims || return 1
+  rm -f "$BATS_TEST_TMPDIR/sysbin/jq"
+}
+
+teardown_aws_shims() {
+  :
+}
+
+# Symlink required system binaries from /usr/bin (preferred) or /bin.
+# aws must NEVER be in this whitelist. jq is handled separately (optional).
+_aws_link_sysbin_whitelist() {
+  local _cmd
+  for _cmd in readlink dirname cat grep cut rm chmod mkdir touch awk tr sed; do
+    if [ -x "/usr/bin/$_cmd" ]; then
+      ln -sf "/usr/bin/$_cmd" "$BATS_TEST_TMPDIR/sysbin/$_cmd"
+    elif [ -x "/bin/$_cmd" ]; then
+      ln -sf "/bin/$_cmd" "$BATS_TEST_TMPDIR/sysbin/$_cmd"
+    else
+      echo "[setup_aws_shims] ERROR: required system binary $_cmd not found in /usr/bin or /bin" >&2
+      return 1
+    fi
+  done
+}
+
+# Optional jq symlink: present iff OS jq is available. AW9 removes it to force
+# the grep/cut fallback path in lib/aws.sh.
+_aws_link_jq_optional() {
+  local _jq_path
+  _jq_path=$(command -v jq 2>/dev/null || true)
+  if [ -n "$_jq_path" ] && [ -x "$_jq_path" ]; then
+    ln -sf "$_jq_path" "$BATS_TEST_TMPDIR/sysbin/jq"
+  fi
+}
+
+_write_aws_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/aws" <<'SHIM'
+#!/bin/sh
+# aws shim: handles `configure export-credentials` and `configure get region`.
+# Controlled by MOCK_AWS_EXPORT_STATE_<KEY>, MOCK_AWS_EXPORT_JSON_<KEY>,
+# MOCK_AWS_REGION_<KEY> where <KEY> is a normalized profile name.
+
+_sub1="${1:-}"
+_sub2="${2:-}"
+
+# Extract --profile <value> from the full argv. If absent, KEY=DEFAULT.
+_profile="-"
+_prev=""
+for _arg in "$@"; do
+  if [ "$_prev" = "--profile" ]; then
+    _profile="$_arg"
+    break
+  fi
+  _prev="$_arg"
+done
+
+# Normalize profile name to a shell-variable-safe suffix [A-Z0-9_]:
+#   [a-z] -> [A-Z], any non-[A-Z0-9_] -> _ (closed normalization).
+if [ "$_profile" = "-" ]; then
+  _key="DEFAULT"
+else
+  _key=$(printf '%s' "$_profile" | tr 'a-z' 'A-Z' | sed 's/[^A-Z0-9_]/_/g')
+fi
+
+# Build argv (space-joined) excluding $0; keep it tab-free for TSV integrity.
+_argv=""
+for _arg in "$@"; do
+  if [ -z "$_argv" ]; then
+    _argv="$_arg"
+  else
+    _argv="$_argv $_arg"
+  fi
+done
+
+_log_row() {
+  # command<TAB>category<TAB>method<TAB>argv<TAB>profile<TAB>exit_code
+  printf 'aws\tconfigure\t%s\t%s\t%s\t%s\n' "$1" "$_argv" "$_profile" "$2" >> "$SHIM_CALLS_LOG"
+}
+
+case "$_sub1 $_sub2" in
+  "configure export-credentials")
+    _state_var="MOCK_AWS_EXPORT_STATE_${_key}"
+    _json_var="MOCK_AWS_EXPORT_JSON_${_key}"
+    eval "_state=\${$_state_var:-ok}"
+    eval "_json=\${$_json_var:-}"
+    case "$_state" in
+      ok)
+        if [ -n "$_json" ]; then
+          printf '%s\n' "$_json"
+        fi
+        _log_row "export-credentials" 0
+        exit 0
+        ;;
+      fail)
+        echo "Unable to locate credentials. You can configure credentials by running \"aws configure\"." >&2
+        _log_row "export-credentials" 255
+        exit 255
+        ;;
+    esac
+    ;;
+  "configure get")
+    if [ "$3" = "region" ]; then
+      _region_var="MOCK_AWS_REGION_${_key}"
+      eval "_region=\${$_region_var:-}"
+      if [ -n "$_region" ]; then
+        printf '%s\n' "$_region"
+        _log_row "get-region" 0
+        exit 0
+      fi
+      _log_row "get-region" 1
+      exit 1
+    fi
+    ;;
+esac
+
+echo "[shim] unknown aws subcommand: $_argv" >&2
+_log_row "unknown" 1
+exit 1
+SHIM
+}
+
+# assert_aws_configure_called <method> <profile>
+#   method: export-credentials | get-region | unknown
+#   profile: profile name (e.g. default / work) or - for absent
+assert_aws_configure_called() {
+  local _method="$1"
+  local _profile="$2"
+  while IFS=$'\t' read -r _c _cat _m _argv _p _ec; do
+    [ "$_c" = "aws" ] || continue
+    [ "$_cat" = "configure" ] || continue
+    [ "$_m" = "$_method" ] || continue
+    [ "$_p" = "$_profile" ] || continue
+    return 0
+  done < "$SHIM_CALLS_LOG"
+  echo "assert_aws_configure_called FAILED: method='$_method' profile='$_profile'" >&2
+  echo "--- shim-calls.log ---" >&2
+  cat "$SHIM_CALLS_LOG" >&2
+  return 1
+}
+
+assert_aws_configure_not_called() {
+  local _method="$1"
+  local _profile="$2"
+  while IFS=$'\t' read -r _c _cat _m _argv _p _ec; do
+    [ "$_c" = "aws" ] || continue
+    [ "$_cat" = "configure" ] || continue
+    [ "$_m" = "$_method" ] || continue
+    [ "$_p" = "$_profile" ] || continue
+    echo "assert_aws_configure_not_called FAILED: method='$_method' profile='$_profile'" >&2
+    return 1
+  done < "$SHIM_CALLS_LOG"
+  return 0
+}
+
+# --- INI assertion helpers ---------------------------------------------------
+# Section matching uses awk with a -v variable bound to the section name so that
+# regex metacharacters (., -, /) in profile names never cause false matches.
+# Same design for both $_aws_config and $_aws_creds.
+
+_aws_ini_file_for_kind() {
+  # $1: config|creds
+  case "$1" in
+    config) printf '%s' "$_aws_config" ;;
+    creds)  printf '%s' "$_aws_creds" ;;
+    *)      return 1 ;;
+  esac
+}
+
+# _aws_assert_section_count <kind> <section> <expected_count>
+_aws_assert_section_count() {
+  local _kind="$1" _section="$2" _expected="$3"
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  local _actual
+  _actual=$(awk -v sec="$_section" 'BEGIN{n=0} { if ($0 == "[" sec "]") n++ } END{print n}' "$_file")
+  if [ "$_actual" = "$_expected" ]; then
+    return 0
+  fi
+  echo "assert_aws_${_kind}_section_count FAILED: section='$_section' expected=$_expected actual=$_actual" >&2
+  echo "--- $_kind file ($_file) ---" >&2
+  cat "$_file" >&2
+  return 1
+}
+
+# _aws_assert_section_exists <kind> <section>
+_aws_assert_section_exists() {
+  local _kind="$1" _section="$2"
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  if awk -v sec="$_section" '$0 == "[" sec "]" { found=1 } END { exit (found ? 0 : 1) }' "$_file"; then
+    return 0
+  fi
+  echo "assert_aws_${_kind}_section FAILED: section='$_section' not found" >&2
+  echo "--- $_kind file ($_file) ---" >&2
+  cat "$_file" >&2
+  return 1
+}
+
+# _aws_assert_section_not_exists <kind> <section>
+_aws_assert_section_not_exists() {
+  local _kind="$1" _section="$2"
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  if awk -v sec="$_section" '$0 == "[" sec "]" { found=1 } END { exit (found ? 0 : 1) }' "$_file"; then
+    echo "assert_aws_${_kind}_section_not_exists FAILED: section='$_section' was found" >&2
+    echo "--- $_kind file ($_file) ---" >&2
+    cat "$_file" >&2
+    return 1
+  fi
+  return 0
+}
+
+# _aws_assert_section_order <kind> <section_1> [<section_2> ...]
+#   Requires the sections in the file appear in the given order. Duplicate names
+#   are treated as separate positions.
+_aws_assert_section_order() {
+  local _kind="$1"
+  shift
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  local _actual
+  _actual=$(awk 'match($0, /^\[.*\]$/) { print substr($0, RSTART+1, RLENGTH-2) }' "$_file" | tr '\n' '|')
+  local _expected=""
+  local _s
+  for _s in "$@"; do
+    _expected="${_expected}${_s}|"
+  done
+  if [ "$_actual" = "$_expected" ]; then
+    return 0
+  fi
+  echo "assert_aws_${_kind}_section_order FAILED: expected='$_expected' actual='$_actual'" >&2
+  echo "--- $_kind file ($_file) ---" >&2
+  cat "$_file" >&2
+  return 1
+}
+
+# _aws_assert_line <kind> <section> <key> <value>
+#   Succeeds if ANY [section] block contains '<key> = <value>'.
+_aws_assert_line() {
+  local _kind="$1" _section="$2" _key="$3" _value="$4"
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  local _needle="$_key = $_value"
+  if awk -v sec="$_section" -v needle="$_needle" '
+    BEGIN { in_sec = 0 }
+    $0 == "[" sec "]" { in_sec = 1; next }
+    /^\[.*\]$/ { in_sec = 0; next }
+    in_sec && $0 == needle { print "match"; exit }
+  ' "$_file" | grep -q match; then
+    return 0
+  fi
+  echo "assert_aws_${_kind}_line FAILED: section='$_section' key='$_key' value='$_value'" >&2
+  echo "--- $_kind file ($_file) ---" >&2
+  cat "$_file" >&2
+  return 1
+}
+
+# _aws_assert_line_in_nth <kind> <section> <nth> <key> <value>
+#   Succeeds if the <nth> (1-origin) [section] block contains '<key> = <value>'.
+_aws_assert_line_in_nth() {
+  local _kind="$1" _section="$2" _nth="$3" _key="$4" _value="$5"
+  local _file
+  _file=$(_aws_ini_file_for_kind "$_kind") || return 1
+  local _needle="$_key = $_value"
+  if awk -v sec="$_section" -v needle="$_needle" -v target="$_nth" '
+    BEGIN { seen = 0; in_sec = 0 }
+    $0 == "[" sec "]" { seen++; in_sec = (seen == target) ? 1 : 0; next }
+    /^\[.*\]$/ { in_sec = 0; next }
+    in_sec && $0 == needle { print "match"; exit }
+  ' "$_file" | grep -q match; then
+    return 0
+  fi
+  echo "assert_aws_${_kind}_line_in_nth FAILED: section='$_section' nth=$_nth key='$_key' value='$_value'" >&2
+  echo "--- $_kind file ($_file) ---" >&2
+  cat "$_file" >&2
+  return 1
+}
+
+# assert_aws_creds_line_absent <section> <key>
+#   Succeeds if NO [section] block contains a line starting with '<key>'.
+#   (Used to verify aws_session_token is omitted when empty.)
+assert_aws_creds_line_absent() {
+  local _section="$1" _key="$2"
+  local _file="$_aws_creds"
+  if awk -v sec="$_section" -v key="$_key" '
+    BEGIN { in_sec = 0 }
+    $0 == "[" sec "]" { in_sec = 1; next }
+    /^\[.*\]$/ { in_sec = 0; next }
+    in_sec {
+      idx = index($0, key " = ")
+      if (idx == 1) { print "match"; exit }
+    }
+  ' "$_file" | grep -q match; then
+    echo "assert_aws_creds_line_absent FAILED: section='$_section' key='$_key' was found" >&2
+    echo "--- creds file ($_file) ---" >&2
+    cat "$_file" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Public wrappers for config side
+assert_aws_config_section()            { _aws_assert_section_exists config "$1"; }
+assert_aws_config_section_not_exists() { _aws_assert_section_not_exists config "$1"; }
+assert_aws_config_section_count()      { _aws_assert_section_count config "$1" "$2"; }
+assert_aws_config_section_order()      { _aws_assert_section_order config "$@"; }
+assert_aws_config_line()               { _aws_assert_line config "$1" "$2" "$3"; }
+assert_aws_config_line_in_nth()        { _aws_assert_line_in_nth config "$1" "$2" "$3" "$4"; }
+
+# Public wrappers for creds side
+assert_aws_creds_section()            { _aws_assert_section_exists creds "$1"; }
+assert_aws_creds_section_not_exists() { _aws_assert_section_not_exists creds "$1"; }
+assert_aws_creds_section_count()      { _aws_assert_section_count creds "$1" "$2"; }
+assert_aws_creds_section_order()      { _aws_assert_section_order creds "$@"; }
+assert_aws_creds_line()               { _aws_assert_line creds "$1" "$2" "$3"; }
+assert_aws_creds_line_in_nth()        { _aws_assert_line_in_nth creds "$1" "$2" "$3" "$4"; }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -263,3 +263,311 @@ assert_shim_not_called() {
   done < "$SHIM_CALLS_LOG"
   return 0
 }
+
+# ----------------------------------------------------------------
+# Unit 002 (ruleset.bats) helpers — PATH shim + sysbin whitelist
+#
+# Spec: .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/
+#       unit_002_ruleset_bats_tests_logical_design.md
+#
+# Strongly isolates PATH to $BATS_TEST_TMPDIR/shim-bin:$BATS_TEST_TMPDIR/sysbin
+# (no /usr/bin, no /bin). sysbin holds symlinks to a whitelist of system
+# binaries needed by bin/jailrun + lib/ruleset.sh + bats test code.
+# shim-calls.log is a 6-column TSV:
+#   command<TAB>category<TAB>method<TAB>argv<TAB>target<TAB>last
+# where `last` is exit_code for normal rows, payload_path for api_payload
+# auxiliary rows (switched by category column).
+# ----------------------------------------------------------------
+
+setup_ruleset_shims() {
+  mkdir -p "$BATS_TEST_TMPDIR/shim-bin"
+  mkdir -p "$BATS_TEST_TMPDIR/sysbin"
+  mkdir -p "$BATS_TEST_TMPDIR/home"
+
+  _ruleset_link_sysbin_whitelist || return 1
+
+  _write_gh_shim
+  _write_git_shim
+
+  chmod +x "$BATS_TEST_TMPDIR/shim-bin"/*
+
+  export PATH="$BATS_TEST_TMPDIR/shim-bin:$BATS_TEST_TMPDIR/sysbin"
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  export USER="jailrun-test"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export SHIM_CALLS_LOG="$BATS_TEST_TMPDIR/shim-calls.log"
+  export GH_PAYLOAD_SEQ="$BATS_TEST_TMPDIR/gh-payload-seq"
+
+  : > "$SHIM_CALLS_LOG"
+  echo 0 > "$GH_PAYLOAD_SEQ"
+}
+
+teardown_ruleset_shims() {
+  :
+}
+
+# Symlink a whitelist of system binaries from /usr/bin (preferred) or /bin
+# into $BATS_TEST_TMPDIR/sysbin. gh must NEVER be in this whitelist.
+_ruleset_link_sysbin_whitelist() {
+  local _cmd
+  for _cmd in readlink dirname cat grep rm chmod; do
+    if [ -x "/usr/bin/$_cmd" ]; then
+      ln -sf "/usr/bin/$_cmd" "$BATS_TEST_TMPDIR/sysbin/$_cmd"
+    elif [ -x "/bin/$_cmd" ]; then
+      ln -sf "/bin/$_cmd" "$BATS_TEST_TMPDIR/sysbin/$_cmd"
+    else
+      echo "[setup_ruleset_shims] ERROR: required system binary $_cmd not found in /usr/bin or /bin" >&2
+      return 1
+    fi
+  done
+}
+
+_write_gh_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/gh" <<'SHIM'
+#!/bin/sh
+_argv="$*"
+_sub="${1:-}"
+
+# gh auth status
+if [ "$_sub" = "auth" ]; then
+  shift
+  _argv_rest="$*"
+  _state="${MOCK_GH_AUTH_STATE:-ok}"
+  case "$_state" in
+    ok)
+      printf 'gh\tapi\t-\t%s\t-\t0\n' "$_argv_rest" >> "$SHIM_CALLS_LOG"
+      exit 0
+      ;;
+    fail)
+      echo "You are not logged into any GitHub hosts." >&2
+      printf 'gh\tapi\t-\t%s\t-\t1\n' "$_argv_rest" >> "$SHIM_CALLS_LOG"
+      exit 1
+      ;;
+  esac
+fi
+
+# gh api ...
+if [ "$_sub" = "api" ]; then
+  shift
+  _argv_rest="$*"
+
+  # Detect --method POST
+  _method="GET"
+  _has_post=0
+  _has_input=0
+  for _arg in "$@"; do
+    if [ "$_method_next" = "1" ]; then
+      _method="$_arg"
+      _method_next=""
+      if [ "$_arg" = "POST" ]; then
+        _has_post=1
+      fi
+      continue
+    fi
+    case "$_arg" in
+      --method) _method_next=1 ;;
+      -) _has_input=1 ;;
+    esac
+  done
+
+  if [ "$_has_post" = "1" ]; then
+    # POST path: read stdin into payload file, extract target
+    _state="${MOCK_GH_POST_STATE:-ok}"
+    _seq=$(cat "$GH_PAYLOAD_SEQ")
+    _seq=$((_seq + 1))
+    echo "$_seq" > "$GH_PAYLOAD_SEQ"
+    _payload_file="$BATS_TEST_TMPDIR/gh-payload-$_seq.json"
+    if [ "$_has_input" = "1" ]; then
+      cat > "$_payload_file"
+    else
+      : > "$_payload_file"
+    fi
+    # Extract target from payload
+    _target="unknown"
+    if grep -F -- '"target": "branch"' "$_payload_file" >/dev/null 2>&1; then
+      _target="branch"
+    elif grep -F -- '"target": "tag"' "$_payload_file" >/dev/null 2>&1; then
+      _target="tag"
+    fi
+    case "$_state" in
+      ok)
+        printf 'gh\tapi\tPOST\t%s\t%s\t0\n' "$_argv_rest" "$_target" >> "$SHIM_CALLS_LOG"
+        printf 'gh\tapi_payload\tPOST\t-\t%s\t%s\n' "$_target" "$_payload_file" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        echo "gh: HTTP 422 Unprocessable Entity" >&2
+        printf 'gh\tapi\tPOST\t%s\t%s\t1\n' "$_argv_rest" "$_target" >> "$SHIM_CALLS_LOG"
+        printf 'gh\tapi_payload\tPOST\t-\t%s\t%s\n' "$_target" "$_payload_file" >> "$SHIM_CALLS_LOG"
+        exit 1
+        ;;
+    esac
+  fi
+
+  # GET path (list)
+  _state="${MOCK_GH_LIST_STATE:-ok}"
+  case "$_state" in
+    ok)
+      if [ -n "${MOCK_GH_RULESETS_NAMES:-}" ]; then
+        printf '%s\n' "$MOCK_GH_RULESETS_NAMES"
+      fi
+      printf 'gh\tapi\tGET\t%s\t-\t0\n' "$_argv_rest" >> "$SHIM_CALLS_LOG"
+      exit 0
+      ;;
+    fail)
+      echo "gh: HTTP 500 Internal Server Error" >&2
+      printf 'gh\tapi\tGET\t%s\t-\t1\n' "$_argv_rest" >> "$SHIM_CALLS_LOG"
+      exit 1
+      ;;
+  esac
+fi
+
+echo "[shim] unknown gh invocation: $_argv" >&2
+printf 'gh\tapi\t-\t%s\t-\t1\n' "$_argv" >> "$SHIM_CALLS_LOG"
+exit 1
+SHIM
+}
+
+_write_git_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/git" <<'SHIM'
+#!/bin/sh
+_argv="$*"
+_sub1="${1:-}"
+_sub2="${2:-}"
+
+if [ "$_sub1" = "remote" ] && [ "$_sub2" = "get-url" ]; then
+  _state="${MOCK_GIT_REMOTE_STATE:-ok}"
+  case "$_state" in
+    ok)
+      printf '%s\n' "${MOCK_GIT_REMOTE_URL:-}"
+      printf 'git\tremote\t-\t%s\t-\t0\n' "$_argv" >> "$SHIM_CALLS_LOG"
+      exit 0
+      ;;
+    empty)
+      printf 'git\tremote\t-\t%s\t-\t0\n' "$_argv" >> "$SHIM_CALLS_LOG"
+      exit 0
+      ;;
+    fail)
+      printf 'git\tremote\t-\t%s\t-\t1\n' "$_argv" >> "$SHIM_CALLS_LOG"
+      exit 1
+      ;;
+  esac
+fi
+
+echo "[shim] unknown git subcommand: $_argv" >&2
+printf 'git\tremote\t-\t%s\t-\t1\n' "$_argv" >> "$SHIM_CALLS_LOG"
+exit 1
+SHIM
+}
+
+# assert_gh_api_called <method> <path_substring> [<target>]
+#   Match rows with command=gh, category=api, exact method, argv contains
+#   path_substring (literal), and optionally target matches exactly.
+assert_gh_api_called() {
+  local _method="$1"
+  local _sub="$2"
+  local _target="${3:-}"
+  while IFS=$'\t' read -r _c _cat _m _argv _t _last; do
+    [ "$_c" = "gh" ] || continue
+    [ "$_cat" = "api" ] || continue
+    [ "$_m" = "$_method" ] || continue
+    if [ -n "$_sub" ]; then
+      printf '%s' "$_argv" | grep -F -- "$_sub" >/dev/null 2>&1 || continue
+    fi
+    if [ -n "$_target" ]; then
+      [ "$_t" = "$_target" ] || continue
+    fi
+    return 0
+  done < "$SHIM_CALLS_LOG"
+  echo "assert_gh_api_called FAILED: method='$_method' sub='$_sub' target='$_target'" >&2
+  echo "--- shim-calls.log ---" >&2
+  cat "$SHIM_CALLS_LOG" >&2
+  return 1
+}
+
+# assert_gh_api_not_called <method> <path_substring> [<target>]
+assert_gh_api_not_called() {
+  local _method="$1"
+  local _sub="$2"
+  local _target="${3:-}"
+  while IFS=$'\t' read -r _c _cat _m _argv _t _last; do
+    [ "$_c" = "gh" ] || continue
+    [ "$_cat" = "api" ] || continue
+    [ "$_m" = "$_method" ] || continue
+    if [ -n "$_sub" ]; then
+      printf '%s' "$_argv" | grep -F -- "$_sub" >/dev/null 2>&1 || continue
+    fi
+    if [ -n "$_target" ]; then
+      [ "$_t" = "$_target" ] || continue
+    fi
+    echo "assert_gh_api_not_called FAILED: method='$_method' sub='$_sub' target='$_target' matched" >&2
+    return 1
+  done < "$SHIM_CALLS_LOG"
+  return 0
+}
+
+# assert_gh_auth_called — gh auth status logged as category=api with argv starting with 'status'
+assert_gh_auth_called() {
+  while IFS=$'\t' read -r _c _cat _m _argv _t _last; do
+    [ "$_c" = "gh" ] || continue
+    [ "$_cat" = "api" ] || continue
+    case "$_argv" in
+      status*) return 0 ;;
+    esac
+  done < "$SHIM_CALLS_LOG"
+  echo "assert_gh_auth_called FAILED: no 'gh auth status' row found" >&2
+  echo "--- shim-calls.log ---" >&2
+  cat "$SHIM_CALLS_LOG" >&2
+  return 1
+}
+
+# assert_gh_auth_not_called
+assert_gh_auth_not_called() {
+  while IFS=$'\t' read -r _c _cat _m _argv _t _last; do
+    [ "$_c" = "gh" ] || continue
+    [ "$_cat" = "api" ] || continue
+    case "$_argv" in
+      status*)
+        echo "assert_gh_auth_not_called FAILED: 'gh auth status' was called" >&2
+        return 1
+        ;;
+    esac
+  done < "$SHIM_CALLS_LOG"
+  return 0
+}
+
+# assert_gh_post_called <target>
+assert_gh_post_called() {
+  assert_gh_api_called POST "rulesets" "$1"
+}
+
+# assert_gh_post_not_called <target>
+assert_gh_post_not_called() {
+  assert_gh_api_not_called POST "rulesets" "$1"
+}
+
+# assert_gh_payload_contains <target> <substring>
+#   Find auxiliary rows with category=api_payload + matching target, then
+#   grep -F the substring in the payload file recorded in `last` column.
+assert_gh_payload_contains() {
+  local _target="$1"
+  local _sub="$2"
+  local _matched=0
+  while IFS=$'\t' read -r _c _cat _m _argv _t _last; do
+    [ "$_c" = "gh" ] || continue
+    [ "$_cat" = "api_payload" ] || continue
+    [ "$_t" = "$_target" ] || continue
+    if [ -f "$_last" ] && grep -F -- "$_sub" "$_last" >/dev/null 2>&1; then
+      return 0
+    fi
+    _matched=1
+  done < "$SHIM_CALLS_LOG"
+  if [ "$_matched" = "1" ]; then
+    echo "assert_gh_payload_contains FAILED: target='$_target' sub='$_sub' not found in any payload" >&2
+  else
+    echo "assert_gh_payload_contains FAILED: no api_payload row for target='$_target'" >&2
+  fi
+  echo "--- shim-calls.log ---" >&2
+  cat "$SHIM_CALLS_LOG" >&2
+  return 1
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -6,3 +6,260 @@ setup_jailrun_env() {
   export JAILRUN_LIB="$BATS_TEST_DIRNAME/../lib"
   export WRAPPER_NAME="claude"
 }
+
+# ----------------------------------------------------------------
+# Unit 001 (token.bats) helpers — PATH shim based Mock Boundary
+#
+# Spec: .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/
+#       unit_001_token_bats_tests_logical_design.md
+#
+# Generates PATH shims in $BATS_TEST_TMPDIR/shim-bin/ that emulate
+# security / secret-tool / stty / uname / curl. Behavior is driven
+# by MOCK_* environment variables set per-test.
+# ----------------------------------------------------------------
+
+setup_token_shims() {
+  mkdir -p "$BATS_TEST_TMPDIR/shim-bin"
+  mkdir -p "$BATS_TEST_TMPDIR/home"
+
+  _write_security_shim
+  _write_secret_tool_shim
+  _write_stty_shim
+  _write_uname_shim
+  _write_curl_shim
+
+  chmod +x "$BATS_TEST_TMPDIR"/shim-bin/*
+
+  export PATH="$BATS_TEST_TMPDIR/shim-bin:$PATH"
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  export USER="jailrun-test"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export SHIM_CALLS_LOG="$BATS_TEST_TMPDIR/shim-calls.log"
+
+  : "${MOCK_TOKEN_VALUE:=ghp_testtoken_for_shim_12345}"
+  export MOCK_TOKEN_VALUE
+
+  : > "$SHIM_CALLS_LOG"
+}
+
+teardown_token_shims() {
+  :
+}
+
+_write_security_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/security" <<'SHIM'
+#!/bin/sh
+_log() {
+  printf 'security\t%s\t%s\n' "$*" "$1_exit" >> "$SHIM_CALLS_LOG" 2>/dev/null || true
+}
+_argv="$*"
+_sub="${1:-}"
+shift 2>/dev/null || true
+case "$_sub" in
+  find-generic-password)
+    _state="${MOCK_SEC_FIND_STATE:-empty}"
+    case "$_state" in
+      empty)
+        printf 'security\t%s\t0\n' "find-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      registered)
+        printf '%s\n' "${MOCK_TOKEN_VALUE}"
+        printf 'security\t%s\t0\n' "find-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        echo "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain." >&2
+        printf 'security\t%s\t44\n' "find-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 44
+        ;;
+    esac
+    ;;
+  add-generic-password)
+    _state="${MOCK_SEC_ADD_STATE:-ok}"
+    case "$_state" in
+      ok)
+        printf 'security\t%s\t0\n' "add-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        echo "security: SecKeychainItemCreateFromContent failed (-25299)" >&2
+        printf 'security\t%s\t45\n' "add-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 45
+        ;;
+    esac
+    ;;
+  delete-generic-password)
+    _state="${MOCK_SEC_DELETE_STATE:-ok}"
+    case "$_state" in
+      ok)
+        printf 'security\t%s\t0\n' "delete-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        printf 'security\t%s\t44\n' "delete-generic-password $*" >> "$SHIM_CALLS_LOG"
+        exit 44
+        ;;
+    esac
+    ;;
+  dump-keychain)
+    _state="${MOCK_SEC_DUMP_STATE:-empty}"
+    case "$_state" in
+      with_entries)
+        printf '%s\n' "${MOCK_SEC_DUMP_OUTPUT:-}"
+        printf 'security\t%s\t0\n' "dump-keychain $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      empty)
+        printf 'security\t%s\t0\n' "dump-keychain $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        echo "security: SecKeychainCopySearchList failed (-25300)" >&2
+        printf 'security\t%s\t1\n' "dump-keychain $*" >> "$SHIM_CALLS_LOG"
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "[shim] unknown security subcommand: $_sub" >&2
+    printf 'security\t%s\t1\n' "$_argv" >> "$SHIM_CALLS_LOG"
+    exit 1
+    ;;
+esac
+SHIM
+}
+
+_write_secret_tool_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/secret-tool" <<'SHIM'
+#!/bin/sh
+_argv="$*"
+_sub="${1:-}"
+shift 2>/dev/null || true
+case "$_sub" in
+  lookup)
+    _state="${MOCK_SECTOOL_LOOKUP_STATE:-empty}"
+    case "$_state" in
+      empty)
+        printf 'secret-tool\t%s\t0\n' "lookup $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      registered)
+        printf '%s' "${MOCK_TOKEN_VALUE}"
+        printf 'secret-tool\t%s\t0\n' "lookup $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        printf 'secret-tool\t%s\t1\n' "lookup $*" >> "$SHIM_CALLS_LOG"
+        exit 1
+        ;;
+    esac
+    ;;
+  store)
+    _state="${MOCK_SECTOOL_STORE_STATE:-ok}"
+    cat >/dev/null 2>&1 || true
+    case "$_state" in
+      ok)
+        printf 'secret-tool\t%s\t0\n' "store $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        printf 'secret-tool\t%s\t1\n' "store $*" >> "$SHIM_CALLS_LOG"
+        exit 1
+        ;;
+    esac
+    ;;
+  clear)
+    _state="${MOCK_SECTOOL_CLEAR_STATE:-ok}"
+    case "$_state" in
+      ok)
+        printf 'secret-tool\t%s\t0\n' "clear $*" >> "$SHIM_CALLS_LOG"
+        exit 0
+        ;;
+      fail)
+        printf 'secret-tool\t%s\t1\n' "clear $*" >> "$SHIM_CALLS_LOG"
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "[shim] unknown secret-tool subcommand: $_sub" >&2
+    printf 'secret-tool\t%s\t1\n' "$_argv" >> "$SHIM_CALLS_LOG"
+    exit 1
+    ;;
+esac
+SHIM
+}
+
+_write_stty_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/stty" <<'SHIM'
+#!/bin/sh
+printf 'stty\t%s\t0\n' "$*" >> "$SHIM_CALLS_LOG"
+exit 0
+SHIM
+}
+
+_write_uname_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/uname" <<'SHIM'
+#!/bin/sh
+_os="${MOCK_UNAME:-Darwin}"
+printf '%s\n' "$_os"
+printf 'uname\t%s\t0\n' "$*" >> "$SHIM_CALLS_LOG"
+exit 0
+SHIM
+}
+
+_write_curl_shim() {
+  cat > "$BATS_TEST_TMPDIR/shim-bin/curl" <<'SHIM'
+#!/bin/sh
+# Emulate `curl -sS -H ... -D - -o /dev/null https://...` used by
+# _check_gh_expiration in lib/token.sh. Return a fixed header with
+# no expiration token so the caller reports "unknown".
+printf 'HTTP/2 200 \r\n'
+printf 'content-type: application/json\r\n'
+printf '\r\n'
+printf 'curl\t%s\t0\n' "$*" >> "$SHIM_CALLS_LOG"
+exit 0
+SHIM
+}
+
+# assert_shim_called <command> [argv_substring]
+#   Fails the bats test if no log line matches.
+#   argv_substring is a literal substring (grep -F semantics; no glob expansion).
+assert_shim_called() {
+  local _cmd="$1"
+  local _sub="${2:-}"
+  while IFS=$'\t' read -r _c _argv _code; do
+    if [ "$_c" = "$_cmd" ]; then
+      if [ -z "$_sub" ]; then
+        return 0
+      fi
+      if printf '%s' "$_argv" | grep -F -- "$_sub" >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done < "$SHIM_CALLS_LOG"
+  echo "assert_shim_called FAILED: cmd='$_cmd' sub='$_sub'" >&2
+  echo "--- shim-calls.log ---" >&2
+  cat "$SHIM_CALLS_LOG" >&2
+  return 1
+}
+
+# assert_shim_not_called <command> [argv_substring]
+assert_shim_not_called() {
+  local _cmd="$1"
+  local _sub="${2:-}"
+  while IFS=$'\t' read -r _c _argv _code; do
+    if [ "$_c" = "$_cmd" ]; then
+      if [ -z "$_sub" ]; then
+        echo "assert_shim_not_called FAILED: cmd='$_cmd' was called" >&2
+        return 1
+      fi
+      if printf '%s' "$_argv" | grep -F -- "$_sub" >/dev/null 2>&1; then
+        echo "assert_shim_not_called FAILED: cmd='$_cmd' sub='$_sub' matched" >&2
+        return 1
+      fi
+    fi
+  done < "$SHIM_CALLS_LOG"
+  return 0
+}

--- a/tests/ruleset.bats
+++ b/tests/ruleset.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+#
+# Tests for `jailrun ruleset` subcommand (lib/ruleset.sh).
+# PATH shims (gh / git) plus a sysbin whitelist directory are defined
+# in tests/helpers.bash. Per-test behavior is controlled via MOCK_* env vars.
+#
+# Test case IDs correspond to:
+#   .aidlc/cycles/v0.3.1/plans/unit-002-plan.md#テストケース設計
+#
+# Design refs:
+#   .aidlc/cycles/v0.3.1/design-artifacts/domain-models/
+#     unit_002_ruleset_bats_tests_domain_model.md
+#   .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/
+#     unit_002_ruleset_bats_tests_logical_design.md
+
+load helpers
+
+setup() {
+  setup_jailrun_env
+  setup_ruleset_shims
+}
+
+teardown() {
+  teardown_ruleset_shims
+}
+
+_jailrun_ruleset() {
+  "$JAILRUN_DIR/jailrun" ruleset "$@"
+}
+
+# ========================================================================
+# 1. 主要シナリオ（apply / skip / 失敗）
+# ========================================================================
+
+@test "RSB1 ruleset: branch/tag 両方とも新規作成 (POST 呼ばれる、payload 部分一致)" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=ok
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 0 ]
+  assert_gh_auth_called
+  assert_gh_post_called branch
+  assert_gh_post_called tag
+  assert_gh_payload_contains branch '"target": "branch"'
+  assert_gh_payload_contains branch '"required_approving_review_count": 1'
+  assert_gh_payload_contains tag '"target": "tag"'
+  assert_gh_payload_contains tag '"include": ["~ALL"]'
+}
+
+@test "RSB2 ruleset: branch 既存スキップ、tag は apply" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES="jailrun-branch-protection"
+  export MOCK_GH_POST_STATE=ok
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exists, skipping"* ]]
+  assert_gh_post_not_called branch
+  assert_gh_post_called tag
+}
+
+@test "RST2 ruleset: tag 既存スキップ、branch は apply" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES="jailrun-tag-protection"
+  export MOCK_GH_POST_STATE=ok
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 0 ]
+  assert_gh_post_called branch
+  assert_gh_post_not_called tag
+}
+
+@test "RSB3 ruleset: 両方既存で POST 一度も呼ばれない" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=$'jailrun-branch-protection\njailrun-tag-protection'
+  export MOCK_GH_POST_STATE=ok
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 0 ]
+  assert_gh_post_not_called branch
+  assert_gh_post_not_called tag
+}
+
+@test "RSF1 ruleset: branch POST 失敗で exit 非 0 (tag POST 失敗も本ケースで代表)" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=fail
+  run _jailrun_ruleset owner/repo
+  [ "$status" -ne 0 ]
+  # branch POST 呼び出し記録はあり (失敗ログ)
+  assert_gh_post_called branch
+}
+
+@test "RSF2 ruleset: list API 失敗時の POST 発火 (本体仕様の明文化)" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=fail
+  export MOCK_GH_POST_STATE=ok
+  run _jailrun_ruleset owner/repo
+  # _ruleset_exists は || true で非 0 を吸収 → 「存在しない」扱いで POST 発火
+  [ "$status" -eq 0 ]
+  assert_gh_post_called branch
+  assert_gh_post_called tag
+}
+
+# ========================================================================
+# 2. 認証・環境ガード
+# ========================================================================
+
+@test "RSG1 ruleset: gh CLI 未インストール (PATH 隔離で決定論的に再現)" {
+  # shim-bin/gh を削除。PATH は shim-bin:sysbin のみ (sysbin に gh なし、
+  # /usr/bin や /bin も PATH 外) のため、実環境 gh への fallthrough なし
+  rm "$BATS_TEST_TMPDIR/shim-bin/gh"
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gh CLI is not installed"* ]]
+  assert_gh_auth_not_called
+}
+
+@test "RSG2 ruleset: gh 未認証 (auth status fail)" {
+  export MOCK_GH_AUTH_STATE=fail
+  run _jailrun_ruleset owner/repo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gh CLI is not authenticated"* ]]
+  assert_gh_auth_called
+  assert_gh_api_not_called GET "rulesets"
+  assert_gh_post_not_called branch
+  assert_gh_post_not_called tag
+}
+
+@test "RSG3 ruleset: --dry-run で auth/list/POST いずれも呼ばれない" {
+  # dry-run は auth check をスキップするため MOCK_GH_AUTH_STATE=fail でも通る
+  export MOCK_GH_AUTH_STATE=fail
+  run _jailrun_ruleset --dry-run owner/repo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(dry-run) would create with:"* ]]
+  assert_gh_auth_not_called
+  assert_gh_api_not_called GET "rulesets"
+  assert_gh_post_not_called branch
+  assert_gh_post_not_called tag
+}
+
+# ========================================================================
+# 3. 引数パース
+# ========================================================================
+
+@test "RSO1 ruleset: --help で usage 出力" {
+  run _jailrun_ruleset --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: jailrun ruleset"* ]]
+  assert_gh_auth_not_called
+}
+
+@test "RSO1b ruleset: -h で usage 出力" {
+  run _jailrun_ruleset -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: jailrun ruleset"* ]]
+  assert_gh_auth_not_called
+}
+
+@test "RSO2 ruleset: 未知オプションで exit 1" {
+  run _jailrun_ruleset --unknown
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+@test "RSO3 ruleset: 位置引数が 2 つ以上で exit 1" {
+  export MOCK_GH_AUTH_STATE=ok
+  run _jailrun_ruleset owner/repo extra
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unexpected argument 'extra'"* ]]
+}
+
+# ========================================================================
+# 4. リポジトリ自動検出
+# ========================================================================
+
+@test "RSR1 ruleset: git@ SSH URL 検出 (引数なし)" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=ok
+  export MOCK_GIT_REMOTE_URL="git@github.com:myorg/myrepo.git"
+  run _jailrun_ruleset
+  [ "$status" -eq 0 ]
+  assert_gh_api_called POST "repos/myorg/myrepo/rulesets"
+}
+
+@test "RSR2 ruleset: https URL 検出" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=ok
+  export MOCK_GIT_REMOTE_URL="https://github.com/myorg/myrepo.git"
+  run _jailrun_ruleset
+  [ "$status" -eq 0 ]
+  assert_gh_api_called POST "repos/myorg/myrepo/rulesets"
+}
+
+@test "RSR3 ruleset: ssh:// URL 検出" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=ok
+  export MOCK_GIT_REMOTE_URL="ssh://git@github.com/myorg/myrepo.git"
+  run _jailrun_ruleset
+  [ "$status" -eq 0 ]
+  assert_gh_api_called POST "repos/myorg/myrepo/rulesets"
+}
+
+@test "RSR4 ruleset: https URL with user@ 検出" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GH_LIST_STATE=ok
+  export MOCK_GH_RULESETS_NAMES=""
+  export MOCK_GH_POST_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=ok
+  export MOCK_GIT_REMOTE_URL="https://user@github.com/myorg/myrepo.git"
+  run _jailrun_ruleset
+  [ "$status" -eq 0 ]
+  assert_gh_api_called POST "repos/myorg/myrepo/rulesets"
+}
+
+@test "RSR5 ruleset: remote 無し (empty) で exit 1" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=empty
+  run _jailrun_ruleset
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no git remote 'origin' found"* ]]
+}
+
+@test "RSR6 ruleset: 未対応 URL 形式で exit 1" {
+  export MOCK_GH_AUTH_STATE=ok
+  export MOCK_GIT_REMOTE_STATE=ok
+  export MOCK_GIT_REMOTE_URL="gitlab.com:myorg/myrepo.git"
+  run _jailrun_ruleset
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsupported remote URL format"* ]]
+}

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Unit tests for lib/config_cli.py."""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+import config  # noqa: E402
+import config_cli  # noqa: E402
+
+
+class ConfigCliTestBase(unittest.TestCase):
+    """Base class: provides tmpdir + dual config_file patch."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.config_path = Path(self._tmpdir.name) / "config.toml"
+
+        p1 = patch("config_cli.config_file", return_value=self.config_path)
+        p2 = patch("config.config_file", return_value=self.config_path)
+        p1.start()
+        self.addCleanup(p1.stop)
+        p2.start()
+        self.addCleanup(p2.stop)
+
+    def write_fixture(self, toml_content: str) -> None:
+        self.config_path.write_text(toml_content)
+
+    def read_config_contents(self) -> str:
+        return self.config_path.read_text()
+
+
+class TestCmdLoad(ConfigCliTestBase):
+    """cmd_load — stdout_only, defaults / app profile / dir longest-prefix."""
+
+    def test_cl1_defaults_config_absent(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_load([])
+        output = buf.getvalue()
+        self.assertIn('GH_TOKEN_NAME="classic"', output)
+        self.assertIn('ALLOWED_AWS_PROFILES="default"', output)
+        self.assertIn('DEFAULT_REGION="ap-northeast-1"', output)
+
+    def test_cl2_app_profile_resolution(self):
+        self.write_fixture(
+            "[global]\n"
+            'gh_token_name = "classic"\n'
+            "\n"
+            "[app.myapp]\n"
+            'profile = "myprofile"\n'
+            "\n"
+            "[profile.myprofile]\n"
+            'gh_token_name = "custom"\n'
+        )
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_load(["--app", "myapp"])
+        output = buf.getvalue()
+        self.assertIn('GH_TOKEN_NAME="custom"', output)
+
+    def test_cl3_dir_longest_prefix_with_list_append(self):
+        self.write_fixture(
+            "[profile.base]\n"
+            'sandbox_passthrough_env = ["BASE"]\n'
+            "\n"
+            '[dir."/tmp/proj"]\n'
+            'sandbox_passthrough_env = ["SHORT"]\n'
+            "\n"
+            '[dir."/tmp/proj/sub"]\n'
+            'profile = "base"\n'
+            'sandbox_passthrough_env = ["X"]\n'
+        )
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_load(["--dir", "/tmp/proj/sub/nested"])
+        output = buf.getvalue()
+        self.assertIn('SANDBOX_PASSTHROUGH_ENV="BASE X"', output)
+        self.assertNotIn("SHORT", output)
+
+
+class TestCmdShow(ConfigCliTestBase):
+    """cmd_show — stdout_only / SystemExit on missing config."""
+
+    def test_cs1_prints_resolved_config(self):
+        self.write_fixture(
+            "[global]\n"
+            'gh_token_name = "xxx"\n'
+        )
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_show([])
+        output = buf.getvalue()
+        self.assertIn('gh_token_name = "xxx"', output)
+        self.assertIn("default_region", output)
+
+    def test_cs2_exits_when_config_absent(self):
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_show([])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("no config file found", err_buf.getvalue())
+
+
+class TestCmdSet(ConfigCliTestBase):
+    """cmd_set — file_write, 5 error paths, --append no-op branch."""
+
+    def _base_fixture(self) -> None:
+        self.write_fixture(
+            "[global]\n"
+            'gh_token_name = "classic"\n'
+            'allowed_aws_profiles = ["default"]\n'
+        )
+
+    def test_cset1_scalar_replace(self):
+        self._base_fixture()
+        config_cli.cmd_set(["gh_token_name", "fine-grained"])
+        content = self.read_config_contents()
+        self.assertIn('gh_token_name = "fine-grained"', content)
+
+    def test_cset2_list_append(self):
+        self._base_fixture()
+        config_cli.cmd_set(["--append", "allowed_aws_profiles", "dev"])
+        content = self.read_config_contents()
+        self.assertIn('allowed_aws_profiles = ["default", "dev"]', content)
+
+    def test_cset3_list_remove(self):
+        self.write_fixture(
+            "[global]\n"
+            'allowed_aws_profiles = ["default", "dev"]\n'
+        )
+        config_cli.cmd_set(["--remove", "allowed_aws_profiles", "dev"])
+        content = self.read_config_contents()
+        self.assertIn('allowed_aws_profiles = ["default"]', content)
+        self.assertNotIn('"dev"', content)
+
+    def test_cset4_exits_when_config_absent(self):
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_set(["gh_token_name", "x"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("no config file found", err_buf.getvalue())
+
+    def test_cset5_exits_when_key_missing(self):
+        self._base_fixture()
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_set([])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("missing KEY", err_buf.getvalue())
+
+    def test_cset6_exits_when_unknown_key(self):
+        self._base_fixture()
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_set(["unknown_key", "v"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("unknown key", err_buf.getvalue())
+
+    def test_cset7_exits_when_append_on_scalar(self):
+        self._base_fixture()
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_set(["--append", "gh_token_name", "x"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("--append is only supported for list-type keys", err_buf.getvalue())
+
+    def test_cset8_exits_when_value_missing(self):
+        self._base_fixture()
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_set(["gh_token_name"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("missing VALUE", err_buf.getvalue())
+
+    def test_cset9_append_duplicate_is_noop(self):
+        self._base_fixture()
+        err_buf = io.StringIO()
+        with patch("config_cli.set_key_in_toml") as mock_set:
+            with contextlib.redirect_stderr(err_buf):
+                config_cli.cmd_set(["--append", "allowed_aws_profiles", "default"])
+            mock_set.assert_not_called()
+        self.assertIn("already in allowed_aws_profiles", err_buf.getvalue())
+        content = self.read_config_contents()
+        self.assertIn('allowed_aws_profiles = ["default"]', content)
+        self.assertNotIn('"default", "default"', content)
+
+
+class TestCmdEdit(ConfigCliTestBase):
+    """cmd_edit — os.execvp mock, EDITOR env toggling."""
+
+    def test_ce1_invokes_editor_from_env(self):
+        self.write_fixture("[global]\n")
+        with patch("config_cli.os.execvp") as mock_execvp, \
+                patch.dict("os.environ", {"EDITOR": "vim"}):
+            config_cli.cmd_edit([])
+        mock_execvp.assert_called_once_with("vim", ["vim", str(self.config_path)])
+
+    def test_ce2_defaults_to_vi_when_editor_unset(self):
+        self.write_fixture("[global]\n")
+        env_without_editor = {k: v for k, v in os.environ.items() if k != "EDITOR"}
+        with patch("config_cli.os.execvp") as mock_execvp, \
+                patch.dict("os.environ", env_without_editor, clear=True):
+            config_cli.cmd_edit([])
+        mock_execvp.assert_called_once_with("vi", ["vi", str(self.config_path)])
+
+    def test_ce3_exits_and_skips_execvp_when_config_absent(self):
+        with patch("config_cli.os.execvp") as mock_execvp:
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_edit([])
+        self.assertEqual(cm.exception.code, 1)
+        mock_execvp.assert_not_called()
+
+
+class TestCmdPath(ConfigCliTestBase):
+    """cmd_path — stdout_only, prints patched config path."""
+
+    def test_cp1_prints_config_path(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_path([])
+        self.assertIn(str(self.config_path), buf.getvalue())
+
+
+class TestCmdInit(ConfigCliTestBase):
+    """cmd_init — file_write, force / existing rejection."""
+
+    def test_ci1_creates_new_config(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_init([])
+        self.assertTrue(self.config_path.exists())
+        content = self.config_path.read_text()
+        self.assertIn("[global]", content)
+        self.assertIn("gh_token_name", content)
+        self.assertIn("created:", buf.getvalue())
+
+    def test_ci2_exits_when_existing_without_force(self):
+        self.write_fixture("[global]\n")
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_cli.cmd_init([])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("config already exists", err_buf.getvalue())
+
+    def test_ci3_overwrites_with_force(self):
+        self.write_fixture("[global]\ngh_token_name = \"old\"\n")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_cli.cmd_init(["--force"])
+        content = self.config_path.read_text()
+        self.assertIn("[global]", content)
+        self.assertIn("gh_token_name", content)
+        self.assertIn("created:", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_migrate.py
+++ b/tests/test_config_migrate.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for lib/config_migrate.py."""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+import config_migrate  # noqa: E402
+
+
+LEGACY_MST1 = (
+    'export GH_TOKEN_NAME="classic"\n'
+    'ALLOWED_AWS_PROFILES="default dev"\n'
+    'DEFAULT_AWS_PROFILE="work"\n'
+    'SANDBOX_PASSTHROUGH_ENV="AWS_REGION HOME"\n'
+)
+
+EXPECTED_MST1_TOML = (
+    "# jailrun config (migrated from shell format)\n"
+    "# Docs: https://github.com/ikeisuke/jailrun\n"
+    "\n"
+    "[global]\n"
+    'gh_token_name = "classic"\n'
+    'allowed_aws_profiles = ["default", "dev"]\n'
+    'default_aws_profile = "work"\n'
+    'default_region = "ap-northeast-1"\n'
+    "sandbox_deny_read_names = []\n"
+    "sandbox_extra_deny_read = []\n"
+    "sandbox_extra_allow_write = []\n"
+    "sandbox_extra_allow_write_files = []\n"
+    'sandbox_passthrough_env = ["AWS_REGION", "HOME"]\n'
+    'proxy_enabled = "False"\n'
+    "proxy_allow_domains = []\n"
+    'keychain_profile = "allow"\n'
+)
+
+EXPECTED_CM1_TOML = EXPECTED_MST1_TOML + "\n"
+
+
+class TestMigrateShellToToml(unittest.TestCase):
+    """migrate_shell_to_toml — pure function, no patch needed."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.legacy_path = Path(self._tmpdir.name) / "config"
+
+    def write_legacy(self, content: str) -> None:
+        self.legacy_path.write_text(content)
+
+    def test_mst1_full_roundtrip_equal(self):
+        self.write_legacy(LEGACY_MST1)
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertEqual(result, EXPECTED_MST1_TOML)
+
+    def test_mst2_github_prefix_stripped(self):
+        self.write_legacy('GH_KEYCHAIN_SERVICE="github:token-name"\n')
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertIn('gh_token_name = "token-name"', result)
+        self.assertNotIn("github:", result)
+
+    def test_mst3_gh_token_name_precedence(self):
+        self.write_legacy(
+            'GH_TOKEN_NAME="new-name"\n'
+            'GH_KEYCHAIN_SERVICE="github:legacy-name"\n'
+        )
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertIn('gh_token_name = "new-name"', result)
+        self.assertNotIn("legacy-name", result)
+
+    def test_mst4_unknown_key_skipped(self):
+        self.write_legacy('UNKNOWN_KEY="x"\n')
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertNotIn("UNKNOWN_KEY", result)
+        self.assertNotIn("unknown_key", result)
+        self.assertIn('gh_token_name = "classic"', result)
+
+    def test_mst5_comment_and_empty_lines_skipped(self):
+        self.write_legacy(
+            "# header comment\n"
+            "\n"
+            "NOEQUALSLINE\n"
+        )
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertNotIn("header comment", result)
+        self.assertNotIn("NOEQUALSLINE", result)
+        self.assertIn('gh_token_name = "classic"', result)
+
+    def test_mst6_empty_list_key(self):
+        self.write_legacy('SANDBOX_PASSTHROUGH_ENV=""\n')
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertIn("sandbox_passthrough_env = []", result)
+
+    def test_mst7_empty_file_yields_defaults(self):
+        self.write_legacy("")
+        result = config_migrate.migrate_shell_to_toml(self.legacy_path)
+        self.assertIn('gh_token_name = "classic"', result)
+        self.assertIn('allowed_aws_profiles = ["default"]', result)
+        self.assertIn('default_aws_profile = "default"', result)
+        self.assertIn('default_region = "ap-northeast-1"', result)
+
+    def test_mst8_missing_path_raises_file_not_found(self):
+        nonexistent = Path("/nonexistent/shell-config-xyz-9f3a2b")
+        with self.assertRaises(FileNotFoundError):
+            config_migrate.migrate_shell_to_toml(nonexistent)
+
+
+class TestCmdMigrate(unittest.TestCase):
+    """cmd_migrate — patches legacy_config_file / config_file on config_migrate."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.legacy_path = Path(self._tmpdir.name) / "config"
+        self.toml_path = Path(self._tmpdir.name) / "config.toml"
+
+        p1 = patch(
+            "config_migrate.legacy_config_file",
+            return_value=self.legacy_path,
+        )
+        p2 = patch(
+            "config_migrate.config_file",
+            return_value=self.toml_path,
+        )
+        p1.start()
+        self.addCleanup(p1.stop)
+        p2.start()
+        self.addCleanup(p2.stop)
+
+    def write_legacy(self, content: str) -> None:
+        self.legacy_path.write_text(content)
+
+    def write_toml(self, content: str) -> None:
+        self.toml_path.write_text(content)
+
+    def test_cm1_writes_expected_toml(self):
+        self.write_legacy(LEGACY_MST1)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_migrate.cmd_migrate([])
+        self.assertTrue(self.toml_path.exists())
+        self.assertEqual(self.toml_path.read_text(), EXPECTED_CM1_TOML)
+        self.assertIn("migrated:", buf.getvalue())
+
+    def test_cm2_exits_when_legacy_absent(self):
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_migrate.cmd_migrate([])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("no legacy config found", err_buf.getvalue())
+
+    def test_cm3_exits_when_toml_exists_without_force(self):
+        self.write_legacy('GH_TOKEN_NAME="x"\n')
+        self.write_toml("[global]\n# existing\n")
+        err_buf = io.StringIO()
+        with contextlib.redirect_stderr(err_buf):
+            with self.assertRaises(SystemExit) as cm:
+                config_migrate.cmd_migrate([])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("TOML config already exists", err_buf.getvalue())
+        self.assertIn("# existing", self.toml_path.read_text())
+
+    def test_cm4_force_overwrites_existing_toml(self):
+        self.write_legacy('GH_TOKEN_NAME="new"\n')
+        self.write_toml("[global]\n# OLD_MARKER\n")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            config_migrate.cmd_migrate(["--force"])
+        content = self.toml_path.read_text()
+        self.assertNotIn("OLD_MARKER", content)
+        self.assertIn("[global]", content)
+        self.assertIn("gh_token_name", content)
+        self.assertIn("migrated:", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/token.bats
+++ b/tests/token.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+#
+# Tests for `jailrun token` subcommands (lib/token.sh).
+# PATH shims (security / secret-tool / stty / uname / curl) are defined
+# in tests/helpers.bash. Per-test behavior is controlled via MOCK_* env vars.
+#
+# Test case IDs correspond to:
+#   .aidlc/cycles/v0.3.1/plans/unit-001-plan.md#テストケース設計
+
+load helpers
+
+setup() {
+  setup_jailrun_env
+  setup_token_shims
+}
+
+teardown() {
+  teardown_token_shims
+}
+
+_jailrun_token() {
+  "$JAILRUN_DIR/jailrun" token "$@"
+}
+
+# ========================================================================
+# _cmd_add
+# ========================================================================
+
+@test "A1 add: Darwin 正常系 (find=empty, add=ok)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=empty
+  export MOCK_SEC_ADD_STATE=ok
+  run bash -c 'printf "mynewtoken\n" | "$JAILRUN_DIR/jailrun" token add --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"saved"* ]]
+  assert_shim_called security "find-generic-password -s jailrun:github:classic -a jailrun-test"
+  assert_shim_called security "add-generic-password -s jailrun:github:classic -a jailrun-test"
+}
+
+@test "A1L add: Linux 正常系 (lookup=empty, store=ok)" {
+  export MOCK_UNAME=Linux
+  export MOCK_SECTOOL_LOOKUP_STATE=empty
+  export MOCK_SECTOOL_STORE_STATE=ok
+  run bash -c 'printf "mynewtoken\n" | "$JAILRUN_DIR/jailrun" token add --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"saved"* ]]
+  assert_shim_called "secret-tool" "lookup service jailrun:github:classic account jailrun-test"
+  assert_shim_called "secret-tool" "store --label=jailrun:github:classic service jailrun:github:classic account jailrun-test"
+}
+
+@test "A2 add: Darwin Keychain 失敗 (find=fail, add=fail)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=fail
+  export MOCK_SEC_ADD_STATE=fail
+  run bash -c 'printf "mynewtoken\n" | "$JAILRUN_DIR/jailrun" token add --name github:classic'
+  [ "$status" -ne 0 ]
+  # fail 吸収後に add 経路まで進んだこと (add が呼ばれて失敗した) を確認
+  assert_shim_called security "find-generic-password -s jailrun:github:classic -a jailrun-test"
+  assert_shim_called security "add-generic-password -s jailrun:github:classic -a jailrun-test"
+}
+
+@test "A3 add: 不正引数 (--name 欠落)" {
+  export MOCK_UNAME=Darwin
+  run _jailrun_token add
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--name is required"* ]]
+}
+
+@test "A4 add: 不正引数 (未知オプション)" {
+  export MOCK_UNAME=Darwin
+  run _jailrun_token add --name foo --other
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown option"* ]]
+}
+
+# ========================================================================
+# _cmd_rotate
+# ========================================================================
+
+@test "R1 rotate: Darwin 正常系 (find=registered, delete=ok, add=ok)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=registered
+  export MOCK_SEC_DELETE_STATE=ok
+  export MOCK_SEC_ADD_STATE=ok
+  run bash -c 'printf "y\nnewtok\n" | "$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated"* ]]
+  # Order: delete before add
+  # Extract the line numbers to verify ordering.
+  _del_line=$(grep -n $'^security\tdelete-generic-password' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  _add_line=$(grep -n $'^security\tadd-generic-password' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  [ -n "$_del_line" ]
+  [ -n "$_add_line" ]
+  [ "$_del_line" -lt "$_add_line" ]
+}
+
+@test "R1L rotate: Linux 正常系 (lookup=registered, clear=ok, store=ok)" {
+  export MOCK_UNAME=Linux
+  export MOCK_SECTOOL_LOOKUP_STATE=registered
+  export MOCK_SECTOOL_CLEAR_STATE=ok
+  export MOCK_SECTOOL_STORE_STATE=ok
+  run bash -c 'printf "y\nnewtok\n" | "$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated"* ]]
+  _clr_line=$(grep -n $'^secret-tool\tclear' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  _sto_line=$(grep -n $'^secret-tool\tstore' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  [ -n "$_clr_line" ]
+  [ -n "$_sto_line" ]
+  [ "$_clr_line" -lt "$_sto_line" ]
+}
+
+@test "R2 rotate: Darwin 未登録 (find=empty)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=empty
+  run bash -c '"$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not registered"* ]]
+}
+
+@test "R2b rotate: Darwin Keychain 失敗 (find=fail, empty と同値)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=fail
+  run bash -c '"$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not registered"* ]]
+}
+
+@test "R3 rotate: 不正引数 (--name 欠落)" {
+  export MOCK_UNAME=Darwin
+  run _jailrun_token rotate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--name is required"* ]]
+}
+
+# ========================================================================
+# _cmd_delete
+# ========================================================================
+
+@test "D1 delete: Darwin 正常系 (find=registered, delete=ok)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=registered
+  export MOCK_SEC_DELETE_STATE=ok
+  run bash -c 'printf "y\n" | "$JAILRUN_DIR/jailrun" token delete --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deleted"* ]]
+  assert_shim_called security "delete-generic-password -s jailrun:github:classic -a jailrun-test"
+}
+
+@test "D1L delete: Linux 正常系 (lookup=registered, clear=ok)" {
+  export MOCK_UNAME=Linux
+  export MOCK_SECTOOL_LOOKUP_STATE=registered
+  export MOCK_SECTOOL_CLEAR_STATE=ok
+  run bash -c 'printf "y\n" | "$JAILRUN_DIR/jailrun" token delete --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deleted"* ]]
+  assert_shim_called "secret-tool" "clear service jailrun:github:classic account jailrun-test"
+}
+
+@test "D2 delete: Darwin 未登録 (find=empty)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=empty
+  run _jailrun_token delete --name github:classic
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not registered"* ]]
+}
+
+@test "D2b delete: Darwin Keychain 失敗 (find=fail, empty と同値)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=fail
+  run _jailrun_token delete --name github:classic
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not registered"* ]]
+}
+
+@test "D3 delete: 不正引数 (--name 欠落)" {
+  export MOCK_UNAME=Darwin
+  run _jailrun_token delete
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--name is required"* ]]
+}
+
+# ========================================================================
+# _cmd_list
+# ========================================================================
+
+@test "L1 list: Darwin 正常系 (dump 2件 + 無関係1件, find=registered)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_DUMP_STATE=with_entries
+  export MOCK_SEC_DUMP_OUTPUT='    "svce"<blob>="jailrun:github:classic"
+    "svce"<blob>="jailrun:github:myorg"
+    "svce"<blob>="com.apple.someapp.other"'
+  export MOCK_SEC_FIND_STATE=registered
+  export MOCK_TOKEN_VALUE=ghp_testtoken_for_shim_12345
+  run _jailrun_token list
+  [ "$status" -eq 0 ]
+  # The unrelated service must not appear in the output.
+  [[ "$output" != *"com.apple.someapp.other"* ]]
+  # Output must be exactly 2 lines, each in `name<TAB>preview` format.
+  [ "${#lines[@]}" -eq 2 ]
+  _expected_preview=$(printf '%.12s...' "$MOCK_TOKEN_VALUE")
+  [ "${lines[0]}" = "$(printf 'github:classic\t%s' "$_expected_preview")" ]
+  [ "${lines[1]}" = "$(printf 'github:myorg\t%s' "$_expected_preview")" ]
+  # Layer 1: dump-keychain was invoked.
+  assert_shim_called security "dump-keychain"
+  # Layer 2: find-generic-password invoked per jailrun: entry.
+  assert_shim_called security "find-generic-password -s jailrun:github:classic -a jailrun-test"
+  assert_shim_called security "find-generic-password -s jailrun:github:myorg -a jailrun-test"
+  # The shim path does not call find for the unrelated service.
+  assert_shim_not_called security "com.apple.someapp.other"
+}
+
+@test "L2a list: Darwin 登録なし (dump=empty)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_DUMP_STATE=empty
+  run _jailrun_token list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no tokens registered"* ]]
+}
+
+@test "L2b list: Darwin security 失敗 (dump=fail, empty と同値)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_DUMP_STATE=fail
+  run _jailrun_token list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no tokens registered"* ]]
+}
+
+@test "L3 list: Linux 分岐 (uname=Linux)" {
+  export MOCK_UNAME=Linux
+  run _jailrun_token list
+  [ "$status" -eq 0 ]
+  # Linux list writes the hint to stderr; bats `run` captures both streams in $output.
+  [[ "$output" == *"specify a known token name"* ]]
+}


### PR DESCRIPTION
## サイクル概要

v0.3.0 のコードベース調査レポート（Unit 006 → Unit 008）で採否確定した 5 件のテストカバレッジ不足（#41-#45）を解消し、`bin/jailrun` の重要サブコマンド（token / ruleset / aws / config）と関連 Python モジュールのテスト基盤を補強する品質補強リリース。

## 含まれる Unit

1. **Unit 001**: `tests/token.bats` 新設（#41 - `_cmd_add` / `_cmd_rotate` / `_cmd_delete` / `_cmd_list` カバー）
2. **Unit 002**: `tests/ruleset.bats` 新設（#42 - `_cmd_ruleset` + `gh api` mock）
3. **Unit 003**: `tests/aws.bats` 新設（#43 - `_setup_aws_credentials` + `aws sts` mock）
4. **Unit 004**: `tests/test_config_cli.py` 新設（#44 - `cmd_*` 関数の直接 unittest）
5. **Unit 005**: `tests/test_config_migrate.py` 新設（#45 - shell→TOML ラウンドトリップ）
6. **Unit 006**: v0.3.1 リリースメタデータ準備（Construction 範囲: `bin/jailrun --version`、`HISTORY.md`、docs 要否判定）

## Closes

- Closes #41
- Closes #42
- Closes #43
- Closes #44
- Closes #45

## 補足

- 本サイクルは**新規テストファイル追加のみで本体コード変更なし**
- Makefile の既存 `test` ターゲット（`bats tests/` + `python3 -m unittest discover`）を維持し、新規テストは自動的に取り込まれる
- Operations Phase で Git タグ `v0.3.1` 付与と main マージを実施
