### PR TITLE
chore: persist rules.git.merge_method=merge

### DIFF
--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -42,7 +42,7 @@ commit_on_phase_complete = true
 branch_mode = "branch"
 unit_branch_enabled = false
 squash_enabled = false
-merge_method = "ask"
+merge_method = "merge"
 draft_pr = "always"
 ai_author_auto_detect = true
 


### PR DESCRIPTION
## 背景

v0.3.1 Operations Phase 7.13（PR #51 マージ時）で AskUserQuestion によりマージ方法 `merge` を選択し、「設定を保存する」を選んだ。その結果 `.aidlc/config.toml` の `rules.git.merge_method` が `ask` → `merge` に書き換わったが、タイミング上 PR #51 には含められず、マージ後にローカル未コミット差分として残っていた。

## 変更内容

- `.aidlc/config.toml`: `rules.git.merge_method = "ask" → "merge"`

## 補足

- v0.3.1 リリース範囲外（follow-up）
- Issue #53（AI-DLC 的リリース手順）と合わせて次サイクル以降で Operations 手順の改善を検討する

## Test plan

- [x] AI-DLC 設定のため動作検証不要（次回 Operations Phase で自動適用を確認）