### PR TITLE
[v0.3.2] 低優先度ハードニング Issue 消化と patch リリース

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,38 @@
 # Change History
 
+## v0.3.2 — 低優先度ハードニング Issue 消化と patch リリース (2026-04-30)
+
+v0.3.0 / v0.3.1 サイクルで採否確定したバックログ Issue 3 件（#52 / #50 / #49）を消化し、defense-in-depth 補強と境界ケースのエラーハンドリング向上を patch リリースとして届けた。
+
+### Changes
+
+#### Tty Guards
+
+- **`lib/token.sh@_cmd_rotate`**: `_cmd_add` と同じ `[ -t 0 ]` ガードを `stty -echo` / `stty echo` の前後に追加し、非 tty 環境（CI / bats / パイプ経由）でも `set -eu` 下で安全に完走するようにした（Issue #52, Unit 001）
+
+#### Error Handling
+
+- **`bin/bump-version`**: `--tag` 経路の先頭で `git rev-parse --git-dir` 事前ガードを追加し、git リポ外実行時に制御された `die()` メッセージ（`[bump-version]` プレフィックス + `--tag requires a git repository`）で終了するよう改善（Issue #50, Unit 002）
+
+#### Defense-in-Depth
+
+- **`lib/sandbox.sh@_build_git_askpass`**: `git-askpass` スクリプトの `chmod +x` を `chmod 0700` に置換し、所有者専用権限を defense-in-depth として明示（Issue #49, Unit 003）
+
+#### Tests
+
+- **`tests/token.bats`**: `_cmd_rotate` の非 tty 検証ケース（R4 通常入力 / R5 EOF / R6 空入力）を追加。stty PATH shim ログ経由のホワイトボックス検証で、ガード分岐が機能していることを確認
+- **`tests/bump_version.bats`**: git リポ外 `--tag` 実行時の制御された die ケース（TG1）を追加。stderr 2 層契約（`[bump-version]` 含む + `--tag requires a git repository` 含む + `fatal: not a git repository` 含まない）で die() 経路通過を担保
+- **`tests/sandbox_profile.bats`**: `_build_git_askpass` 後の mode 0700 検証ケース（GA1）を追加。前提条件チェック付きクリーンアップで `$output` 空時の二次被害を回避
+- **`tests/helpers.bash`**: OS 分岐共通ヘルパー `assert_file_mode` を新規追加（Darwin BSD `stat -f %A` / Linux GNU `stat -c %a` 対応、3 桁正規化、戻り値 0=一致 / 1=不一致 / 2=非対応プラットフォーム）
+
+#### Version Management
+
+- **`bin/jailrun` VERSION**: `0.3.1` → `0.3.2`（`bin/bump-version 0.3.2 --message "低優先度ハードニング Issue 消化と patch リリース"` 経由で `bin/jailrun` VERSION 行と `HISTORY.md` 先頭見出しを同時更新、Unit 004）
+
+### Compatibility
+
+既存の挙動・インターフェースは維持。`make test` 全体（bats 172 + Python 59 = 231 件）が緑であることを確認済み。
+
 ## v0.3.1 — テスト基盤補強・5 領域の回帰保護を確立 (2026-04-23)
 
 v0.3.0 のコードベース調査で特定されたテストカバレッジ不足 5 領域を全て解消。bats（token/ruleset/aws）と Python unittest（config_cli/config_migrate）を組み合わせ、本体コード無変更で品質補強リリースを届けた。

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -298,6 +298,7 @@ main() {
 
   # git-dependent checks only run for real executions; --dry-run performs no git operations.
   if [ "$_ARG_TAG" -eq 1 ] && [ "$_ARG_DRY_RUN" -eq 0 ]; then
+    git rev-parse --git-dir >/dev/null 2>&1 || die "--tag requires a git repository"
     assert_no_existing_tag "$_version_norm"
     assert_clean_worktree
   fi

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -11,7 +11,7 @@
 
 set -eu
 
-VERSION="0.3.1"
+VERSION="0.3.2"
 
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -152,7 +152,7 @@ esac
 
 _build_git_askpass() {
   printf '#!/bin/sh\necho "$GH_TOKEN"\n' > "$_tmpdir/git-askpass"
-  chmod +x "$_tmpdir/git-askpass"
+  chmod 0700 "$_tmpdir/git-askpass"
 }
 
 # generate env var spec file (SET/UNSET format)

--- a/lib/token.sh
+++ b/lib/token.sh
@@ -166,10 +166,9 @@ _cmd_rotate() {
   esac
 
   printf '[%s] Enter new token: ' "$_name"
-  stty -echo
+  if [ -t 0 ]; then stty -echo; fi
   read _token
-  stty echo
-  echo
+  if [ -t 0 ]; then stty echo; echo; fi
 
   if [ -z "$_token" ]; then
     echo "[$_name] empty input, skipping"

--- a/tests/bump_version.bats
+++ b/tests/bump_version.bats
@@ -98,6 +98,28 @@ assert_no_state_change() {
   grep -q "Release via stdin" HISTORY.md
 }
 
+@test "TG1 --tag fails outside a git repository with controlled die message" {
+  # NOTE: Cycle v0.3.2 / Unit 002 / Issue #50
+  # 事前ガード (git rev-parse --git-dir) が _ARG_TAG=1 && _ARG_DRY_RUN=0 経路で発火し、
+  # 制御された die() メッセージで終了することを検証する。
+  NONGIT="$BATS_TEST_TMPDIR/nongit"
+  mkdir -p "$NONGIT/bin"
+  cp -p bin/jailrun "$NONGIT/bin/jailrun"
+  cp -p HISTORY.md "$NONGIT/HISTORY.md"
+  cd "$NONGIT"
+  [ ! -d .git ]
+  run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
+  [ "$status" -eq 1 ]
+  # die() 経路通過の証拠: [bump-version] プレフィックスを含む
+  [[ "$output" == *"[bump-version]"* ]]
+  # 制御メッセージ本文を含む
+  [[ "$output" == *"--tag requires a git repository"* ]]
+  # 生 git エラーが露出していない
+  [[ "$output" != *"fatal: not a git repository"* ]]
+  # ファイル変更なし (VERSION は fixture の 0.1.0 のまま)
+  grep -qE '^VERSION="0\.1\.0"$' bin/jailrun
+}
+
 @test "--tag creates git tag v<version>" {
   run "$BUMP_VERSION" 0.2.0 --message "Release 0.2.0" --tag
   [ "$status" -eq 0 ]

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -265,6 +265,41 @@ assert_shim_not_called() {
 }
 
 # ----------------------------------------------------------------
+# Cross-platform file mode assertion (Cycle v0.3.2 / Unit 003)
+#
+# Spec: .aidlc/cycles/v0.3.2/design-artifacts/logical-designs/
+#       unit_003_git_askpass_chmod_0700_logical_design.md
+#
+# Supported: Darwin (BSD stat -f %A) / Linux (GNU coreutils stat -c %a).
+# Mode is normalized to 3-digit octal (leading 0 stripped) before compare.
+# Returns: 0=match / 1=mismatch / 2=unsupported platform.
+# ----------------------------------------------------------------
+
+assert_file_mode() {
+  local _path="$1"
+  local _expected="$2"
+  local _actual
+  case "$(uname)" in
+    Darwin)
+      _actual=$(stat -f %A "$_path")
+      ;;
+    Linux)
+      _actual=$(stat -c %a "$_path")
+      ;;
+    *)
+      printf 'assert_file_mode: unsupported platform: %s\n' "$(uname)" >&2
+      return 2
+      ;;
+  esac
+  _actual="${_actual#0}"
+  local _expected_norm="${_expected#0}"
+  [ "$_actual" = "$_expected_norm" ] || {
+    printf 'expected mode %s, got %s for %s\n' "$_expected_norm" "$_actual" "$_path" >&2
+    return 1
+  }
+}
+
+# ----------------------------------------------------------------
 # Unit 002 (ruleset.bats) helpers — PATH shim + sysbin whitelist
 #
 # Spec: .aidlc/cycles/v0.3.1/design-artifacts/logical-designs/

--- a/tests/sandbox_profile.bats
+++ b/tests/sandbox_profile.bats
@@ -289,3 +289,29 @@ CONF
   [[ "$output" == *'export _CREDENTIAL_GUARD_SANDBOXED="1"'* ]]
   [[ "$output" == *'export SSH_AUTH_SOCK=""'* ]]
 }
+
+@test "GA1: _build_git_askpass writes git-askpass with mode 0700 (defense-in-depth)" {
+  # Cycle v0.3.2 / Unit 003 / Issue #49
+  # Spec: .aidlc/cycles/v0.3.2/design-artifacts/logical-designs/
+  #       unit_003_git_askpass_chmod_0700_logical_design.md
+  setup_jailrun_env
+  export _CREDENTIAL_GUARD_SANDBOXED=""
+
+  run env -u _CREDENTIAL_GUARD_SANDBOXED sh -c '
+    export JAILRUN_LIB="'"$JAILRUN_LIB"'"
+    . "$JAILRUN_LIB/sandbox.sh"
+    _tmpdir=$(mktemp -d)
+    _build_git_askpass
+    printf "%s\n" "$_tmpdir/git-askpass"
+  ' 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  _askpass_path="$output"
+  # 前提条件チェック ($output 空・不存在時の二次被害回避)
+  [ -n "$_askpass_path" ]
+  [ -f "$_askpass_path" ]
+  assert_file_mode "$_askpass_path" "700"
+  # 二重ガード後にクリーンアップ
+  _tmpdir_for_test="$(dirname "$_askpass_path")"
+  [ -n "$_tmpdir_for_test" ] && [ -d "$_tmpdir_for_test" ] && rm -rf "$_tmpdir_for_test"
+}

--- a/tests/token.bats
+++ b/tests/token.bats
@@ -132,6 +132,60 @@ _jailrun_token() {
   [[ "$output" == *"--name is required"* ]]
 }
 
+# ------------------------------------------------------------------------
+# Non-tty guard cases (Cycle v0.3.2 / Unit 001 / Issue #52)
+# Spec: .aidlc/cycles/v0.3.2/design-artifacts/logical-designs/
+#       unit_001_token_rotate_tty_guard_logical_design.md
+# ------------------------------------------------------------------------
+
+@test "R4 rotate: 非 tty 通常入力 (guard skips stty, Keychain updated)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=registered
+  export MOCK_SEC_DELETE_STATE=ok
+  export MOCK_SEC_ADD_STATE=ok
+  run bash -c 'printf "y\nnewtok\n" | "$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated"* ]]
+  # ガードが機能して非 tty 環境では stty が呼ばれないことを確認
+  assert_shim_not_called stty
+  # Keychain delete + add の順序確認 (R1 と同じ動作を保証)
+  _del_line=$(grep -n $'^security\tdelete-generic-password' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  _add_line=$(grep -n $'^security\tadd-generic-password' "$SHIM_CALLS_LOG" | head -1 | cut -d: -f1)
+  [ -n "$_del_line" ]
+  [ -n "$_add_line" ]
+  [ "$_del_line" -lt "$_add_line" ]
+}
+
+@test "R5 rotate: 非 tty EOF (token input, no Keychain side-effect)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=registered
+  # confirm に y を渡した後、トークン入力で EOF (パイプ閉じ)
+  run bash -c 'printf "y\n" | "$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  # set -eu 下で read _token が EOF で失敗 → 関数停止 (厳密なコード値は問わず非 0 のみ確認)
+  [ "$status" -ne 0 ]
+  # ガードによりスキップされ "stty: stdin isn't a terminal" は出ない
+  [[ "$output" != *"stty: stdin isn't a terminal"* ]]
+  # Keychain への副作用なし (delete / add が呼ばれない)
+  assert_shim_not_called security "delete-generic-password"
+  assert_shim_not_called security "add-generic-password"
+  # 非 tty では stty 自体も呼ばれない
+  assert_shim_not_called stty
+}
+
+@test "R6 rotate: 非 tty 空入力 (empty input, skipping)" {
+  export MOCK_UNAME=Darwin
+  export MOCK_SEC_FIND_STATE=registered
+  # confirm に y、トークン入力に空行 (改行のみ)
+  run bash -c 'printf "y\n\n" | "$JAILRUN_DIR/jailrun" token rotate --name github:classic'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"empty input, skipping"* ]]
+  # 空入力時は Keychain 更新が走らないことを確認
+  assert_shim_not_called security "delete-generic-password"
+  assert_shim_not_called security "add-generic-password"
+  # 非 tty では stty 自体も呼ばれない
+  assert_shim_not_called stty
+}
+
 # ========================================================================
 # _cmd_delete
 # ========================================================================


### PR DESCRIPTION
## Summary

v0.3.0 / v0.3.1 サイクルで採否確定したバックログ Issue 3 件（#52 / #50 / #49、いずれも `priority:low` の chore / refactor / security 系小修正）を消化し、defense-in-depth 補強と境界ケースのエラーハンドリング向上を **v0.3.2 patch リリース** として届けます。

## 受け入れ基準

- **#52 (Unit 001)**: `lib/token.sh@_cmd_rotate` に `_cmd_add` と同じ `[ -t 0 ]` ガードを `stty -echo` / `stty echo` の前後に追加し、非 tty 環境（CI / bats / パイプ経由）でも `set -eu` 下で安全に完走する。`tests/token.bats` に R4/R5/R6（非 tty 通常入力 / EOF / 空入力）の 3 ケースを追加。
- **#50 (Unit 002)**: `bin/bump-version` の `--tag` 経路の先頭に `git rev-parse --git-dir` 事前ガードを追加し、git リポ外実行時に `[bump-version] error: --tag requires a git repository` という制御された `die()` メッセージで終了する。`tests/bump_version.bats` に TG1（git リポ外 `--tag` 実行）ケースを追加。
- **#49 (Unit 003)**: `lib/sandbox.sh@_build_git_askpass` の `chmod +x` を `chmod 0700` に置換し、所有者専用権限を defense-in-depth として明示。`tests/sandbox_profile.bats` に GA1（mode 0700 検証）ケースを追加し、`tests/helpers.bash` に OS 分岐共通ヘルパー `assert_file_mode`（Darwin BSD stat / Linux GNU stat 対応、3 桁正規化）を新設。
- **Unit 004（リリース準備）**: `bin/jailrun` の VERSION 行を `0.3.1` → `0.3.2` に更新（`bin/bump-version 0.3.2 --message "..."` 経由）、`HISTORY.md` 先頭に v0.3.2 詳細エントリ（v0.3.1 と同じ階層構造）を追記。

## 変更概要

### Tty Guards (#52, Unit 001)

- `lib/token.sh@_cmd_rotate`: `_cmd_add` と同じ `[ -t 0 ]` ガードを `stty -echo` / `stty echo` の前後に追加

### Error Handling (#50, Unit 002)

- `bin/bump-version`: `--tag` 経路の先頭に `git rev-parse --git-dir` 事前ガードを追加し、`die("--tag requires a git repository")` で制御終了

### Defense-in-Depth (#49, Unit 003)

- `lib/sandbox.sh@_build_git_askpass`: `git-askpass` スクリプトに `chmod 0700` を明示し、所有者専用権限を defense-in-depth として保証

### Tests

- `tests/token.bats`: R4/R5/R6（非 tty 通常入力 / EOF / 空入力）3 ケース追加
- `tests/bump_version.bats`: TG1（git リポ外 `--tag` 実行）1 ケース追加
- `tests/sandbox_profile.bats`: GA1（mode 0700 検証）1 ケース追加
- `tests/helpers.bash`: OS 分岐共通ヘルパー `assert_file_mode` を新設（Darwin BSD stat / Linux GNU stat 対応）

### Version Management (Unit 004)

- `bin/jailrun` VERSION: `0.3.1` → `0.3.2`
- `HISTORY.md`: v0.3.2 詳細エントリ追加（v0.3.1 と同じ階層構造）

## Test plan

- [x] `make test` 全体（bats 172 + Python 59 = 231 件）pass
- [x] `bin/jailrun --version` が `jailrun 0.3.2` を出力
- [x] AI レビュー（codex）全 Unit で auto_approved 達成
  - Unit 001: 計画 3 / 設計 3（5 件 → 4 件修正 + 1 件 → Issue #57 にバックログ化）/ コード 1（0 件）/ 統合 1（0 件）
  - Unit 002: 計画 1 / 設計 2（3 件 → 3 件修正）/ コード 1（0 件）/ 統合 1（2 件 → 2 件修正）
  - Unit 003: 計画 1 / 設計 4（4 件 → 4 件修正）/ コード 1（0 件）/ 統合 1（0 件）
  - Unit 004: 計画 3（4 件 → 4 件修正）/ 設計 3（8 件 → 8 件修正）/ コード 1（1 件 → 1 件修正）/ 統合 1（2 件 → 2 件修正）

## Closes

Closes #52
Closes #50
Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
