### PR TITLE
chore: add retrospective conversation-required rule to .aidlc/rules.md

### DIFF
--- a/.aidlc/rules.md
+++ b/.aidlc/rules.md
@@ -18,3 +18,29 @@
 - Issue #53（AI-DLC 的リリース手順）は untrack 方針を前提に運用する（クローズ要否は別途判断）
 
 **例外**: `.aidlc/config.toml` / `.aidlc/rules.md` / `.aidlc/operations.md` 等の `.aidlc/` 直下ファイルは tracked 対象（`.gitignore` パターンは `.aidlc/cycles/` のみ）。
+
+## 振り返り（Retrospective）の進め方
+
+### 対話必須ルール【絶対遵守】
+
+Operations Phase の振り返り（`steps/operations/04-completion.md` §1）を実施する際は、AI エージェントが KPT / Try / Problem を独断で生成して `gh issue create` してはならない。**必ずユーザーとの対話を経て、AskUserQuestion で項目ごとに要否・内容・mirror 送信可否を確認する**こと。
+
+**根拠**: v0.3.4 Operations Phase で AI エージェントが対話なしに振り返り Issue #70 を作成した運用ミス（同 Issue 問題 6 参照）への再発防止。
+
+**手順（最低限）**:
+
+1. KPT 案 / Problem 候補 / Try 候補を提示する前に、ユーザーに「振り返りを実施するか」を AskUserQuestion で確認（`feedback_mode=disabled` 以外の場合）
+2. 各 Problem について以下を 1 項目ずつ AskUserQuestion で対話確認:
+   - 内容に過不足ないか
+   - 主因切り分け（プロダクト固有 / AI-DLC Starter Kit 固有 / 両方に責任）
+   - mirror 送信（AI-DLC feedback 起票）の可否（送信する / しない / 保留）
+3. 関連 Issue が既に存在する場合は、振り返り Issue 本文に重複記載せず、既存 Issue へのコメント統合を提案する（v0.3.4 で #66 へ Self-Healing 経緯を統合した形式）
+4. 全項目確定後に `gh issue create` または `gh api PATCH` で本文反映
+
+**禁止事項**:
+
+- AskUserQuestion を経ずに振り返り Issue を新規作成すること
+- AskUserQuestion を経ずに既存振り返り Issue の本文を一括書き換えすること
+- 「auto mode 中だから対話を省く」判断（auto mode は低リスク・反復作業向けで、振り返りのような判断要件には適用されない）
+
+**例外**: `feedback_mode=disabled` の場合のみ §1 全体をスキップ。`silent` / `mirror` のいずれでも上記対話必須ルールが適用される。


### PR DESCRIPTION
## Summary

v0.3.4 Operations Phase で AI エージェントが対話なしに Retrospective Issue #70 を独断作成した運用ミス（同 Issue 問題 6 参照）への再発防止。

`.aidlc/rules.md` に「振り返りは必ず対話で実施、Issue 起票前に AskUserQuestion で要否・内容・mirror 送信可否を 1 項目ずつ確認する」のローカルルールを追記。

## 変更内容

- `.aidlc/rules.md` 末尾に「振り返り（Retrospective）の進め方」セクション追加（26 行）
- 対話必須ルールの根拠 / 最低限の手順（KPT 案提示前確認 → Problem 1 項目ずつ対話 → 既存 Issue への重複統合提案 → 確定後 gh api PATCH）/ 禁止事項（auto mode を理由とした対話省略禁止）を明記

## 関連 Issue

- Refs #70（Retrospective: v0.3.4、問題 6）

## Test plan

- [x] `.aidlc/rules.md` の体裁確認（既存「ファイル管理方針」セクションと同レベル H2 で追加）
- [x] CI 影響なし（コード変更なし、ドキュメントのみ）

## サイクル外コミットの位置付け

本 PR は v0.3.5 サイクル開始前の chore 修正で、AI-DLC サイクル管理外。スコープを `.aidlc/rules.md` 1 ファイルに限定しており、長期保守対象のローカルルールを早期に固定化する目的。
