### PR TITLE
サイクル v0.3.5

### DIFF
--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -112,7 +112,10 @@ mode = "semi_auto"
 # リリース設定（v2.1.6で追加）
 # changelog: true | false - CHANGELOG自動更新（デフォルト: false）
 # version_tag: true | false - gitタグ作成（デフォルト: false）
-changelog = true
+# v0.3.5: HISTORY.md と CHANGELOG.md の二重化リスク回避のため false に戻す
+# （v0.3.4 振り返り Issue #70 問題 5 / B-staged 方針）。v0.4.0 で
+# HISTORY.md → CHANGELOG.md 段階移行 Unit を計画後、再度 true 化を検討する。
+changelog = false
 version_tag = true
 
 [rules.depth_level]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Change History
 
-## v0.3.5 — Linux CI skip 解除と dash bashism 不整合の根本原因対処（patch リリース） (TBD)
+## v0.3.5 — Linux CI skip 解除と dash bashism 不整合の根本原因対処（patch リリース） (2026-05-07)
 
 v0.3.4 Unit 001 で暫定 skip した bats テスト 8 件（`tests/token.bats` 7 件 + `tests/jailrun.bats` 1 件）の Linux skip ガードを解除し、ubuntu-latest 失敗ログから根本原因を特定・最小修正で両 OS green を達成する patch リリース。Issue #66 を close する。
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,25 @@
 # Change History
 
+## v0.3.5 — Linux CI skip 解除と dash bashism 不整合の根本原因対処（patch リリース） (TBD)
+
+v0.3.4 Unit 001 で暫定 skip した bats テスト 8 件（`tests/token.bats` 7 件 + `tests/jailrun.bats` 1 件）の Linux skip ガードを解除し、ubuntu-latest 失敗ログから根本原因を特定・最小修正で両 OS green を達成する patch リリース。Issue #66 を close する。
+
+### Changes
+
+#### Tests
+
+- **`tests/token.bats`** Linux skip ガード 7 箇所削除（A1 / A1L / A2 / R1 / R1L / R4 / R6）。`case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac` 2 行ずつを除去（Unit 001、Issue #66 Closes）
+- **`tests/jailrun.bats`** Linux skip ガード 1 箇所削除（`jailrun with no args shows help`）。`if [ "$(uname)" = "Linux" ]; then skip ...; fi` 2 行を除去
+
+#### Production
+
+- **`bin/jailrun`** shebang を `#!/bin/sh` から `#!/bin/bash` に変更（Unit 001、Self-Healing 1）。ubuntu-latest の `/bin/sh`（dash）で `shift 2>/dev/null || true` が no-args fatal shell error を起こす問題を回避（POSIX dash の `shift` は `||` で catch 不可）
+- **`lib/token.sh`** shebang を `#!/bin/sh` から `#!/bin/bash` に変更（Unit 001、Self-Healing 1）。`_cmd_add` / `_cmd_rotate` 内 `_saved_trap=$(trap -p INT TERM)` が dash で `Illegal option -p`（POSIX trap は `-p` 非対応、bash 拡張）になる問題を回避
+
+shebang を `#!/usr/bin/env bash` ではなく `#!/bin/bash`（絶対パス）にした理由: `tests/ruleset.bats` の PATH 完全 isolation（`setup_ruleset_shims` の sysbin whitelist）下で `/usr/bin/env` が解決できず exit 127 になるため。
+
+最終 CI 結果: macos-latest pass 179 / skip 0、ubuntu-latest pass 165 / skip 14 / fail 0（baseline 比 ubuntu pass +8 / skip -8）。`.aidlc/cycles/v0.3.5/findings.md` に baseline / Self-Healing 履歴 / 修正対象一覧を保存。
+
 ## v0.3.4 — Linux CI 復活 + GitHub Actions SHA pin + lib/token.sh trap chain（patch リリース） (2026-05-06)
 
 v0.3.3 サイクル振り返り（Issue #64）由来のハードニング 3 件（#62 Linux CI 復活 / #60 GitHub Actions SHA pin / #63 lib/token.sh trap chain）を一括して解消する patch リリース。あわせて main の branch protection に必須 CI チェックを登録し、v0.3.3 振り返り問題 4（PR マージ時の `error:checks-status-unknown` バイパス）を構造的に解消する。

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -11,7 +11,7 @@
 
 set -eu
 
-VERSION="0.3.4"
+VERSION="0.3.5"
 
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # jailrun - AI agent security wrapper
 # Launch AI coding agents with credential isolation + OS sandbox
 #

--- a/lib/token.sh
+++ b/lib/token.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Token management (macOS Keychain / Linux GNOME Keyring)
 # Usage: jailrun token <subcommand> [options]
 #

--- a/tests/jailrun.bats
+++ b/tests/jailrun.bats
@@ -21,8 +21,6 @@
 }
 
 @test "jailrun with no args shows help" {
-  # Linux failure tracked in Issue #66 (Cycle v0.3.4 Unit 001 / status -eq 0 fails on ubuntu-latest)
-  if [ "$(uname)" = "Linux" ]; then skip "Linux failure tracked in #66"; fi
   run bin/jailrun
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage: jailrun"* ]]

--- a/tests/token.bats
+++ b/tests/token.bats
@@ -27,8 +27,6 @@ _jailrun_token() {
 # ========================================================================
 
 @test "A1 add: Darwin success (find=empty, add=ok)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Darwin
   export MOCK_SEC_FIND_STATE=empty
   export MOCK_SEC_ADD_STATE=ok
@@ -40,8 +38,6 @@ _jailrun_token() {
 }
 
 @test "A1L add: Linux success (lookup=empty, store=ok)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Linux
   export MOCK_SECTOOL_LOOKUP_STATE=empty
   export MOCK_SECTOOL_STORE_STATE=ok
@@ -53,8 +49,6 @@ _jailrun_token() {
 }
 
 @test "A2 add: Darwin Keychain failure (find=fail, add=fail)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Darwin
   export MOCK_SEC_FIND_STATE=fail
   export MOCK_SEC_ADD_STATE=fail
@@ -106,8 +100,6 @@ _jailrun_token() {
 # ========================================================================
 
 @test "R1 rotate: Darwin success (find=registered, delete=ok, add=ok)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Darwin
   export MOCK_SEC_FIND_STATE=registered
   export MOCK_SEC_DELETE_STATE=ok
@@ -125,8 +117,6 @@ _jailrun_token() {
 }
 
 @test "R1L rotate: Linux success (lookup=registered, clear=ok, store=ok)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Linux
   export MOCK_SECTOOL_LOOKUP_STATE=registered
   export MOCK_SECTOOL_CLEAR_STATE=ok
@@ -171,8 +161,6 @@ _jailrun_token() {
 # ------------------------------------------------------------------------
 
 @test "R4 rotate: non-tty normal input (guard skips stty, Keychain updated)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Darwin
   export MOCK_SEC_FIND_STATE=registered
   export MOCK_SEC_DELETE_STATE=ok
@@ -207,8 +195,6 @@ _jailrun_token() {
 }
 
 @test "R6 rotate: non-tty empty input (empty input, skipping)" {
-  # Linux failure tracked in Issue #66 (PATH shim or OS dispatch root cause)
-  case "$OSTYPE" in linux*) skip "Linux failure tracked in #66" ;; esac
   export MOCK_UNAME=Darwin
   export MOCK_SEC_FIND_STATE=registered
   # confirm に y、トークン入力に空行 (改行のみ)


### PR DESCRIPTION
## サイクル概要

v0.3.4 で復活させた Linux CI のうち、暫定 skip 中だった bats テスト 8 件（`tests/token.bats` 7 件 + `tests/jailrun.bats` 1 件）の skip ガードを解除し、両 OS（macOS / Linux）で CI を green にする patch リリース。

## 含まれるUnit

- Unit 001: Linux CI skip 解除と根本原因対処 (`.aidlc/cycles/v0.3.5/story-artifacts/units/001-linux-ci-skip-removal.md`)

## サイクル方針

- アプローチ: B（OS 判定統一 / `case "$(uname)"` 一本化、ただし v0.3.4 Self-Healing 2 で本体側は実施済のため実体は調査主導）
- 範囲: 8 件すべて一括解除
- Linux 検証: GitHub Actions ubuntu-latest のみ
- HISTORY/CHANGELOG 二重化回避: `release.changelog=false` 戻し済み（commit 4722900）
- 出口基準（Operations 側で扱う）: Issue #66 close、Issue #64 / #70 close 判断

## Closes

- Closes #66

## 関連

- Relates to #62 (Linux CI 復活、v0.3.4 で対応済)
- Relates to #70 (v0.3.4 振り返り、本サイクルの引継ぎ元)

このPRはOperations Phase完了時にReady for Reviewに変更されます。
