### PR TITLE
feat: WSL2 network restriction via network namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,21 +136,10 @@ agent can only reach the proxy:
 sudo scripts/wsl2-netns-setup.sh
 ```
 
-Then run the proxy on `10.200.0.1:7890` (host namespace) and launch the
-agent inside the namespace:
-
-```bash
-sudo ip netns exec agentns sudo -u "$USER" env \
-  HTTPS_PROXY=http://10.200.0.1:7890 \
-  HTTP_PROXY=http://10.200.0.1:7890 \
-  NO_PROXY=localhost,127.0.0.1 \
-  jailrun claude
-```
-
 This is kernel-enforced and cannot be bypassed from inside the namespace.
 
 When the `agentns` namespace exists, jailrun automatically detects it and:
-- Binds the proxy to `10.200.0.1:7890` instead of `127.0.0.1`
+- Binds the proxy to `10.200.0.1` (ephemeral port) instead of `127.0.0.1`
 - Launches the agent inside the namespace via `sudo ip netns exec`
 
 So after running the setup script, a normal `jailrun claude` will use the

--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ This blocks both reading existing credentials and creating or overwriting
 them from inside the sandbox. Non-credential files (e.g. `notes.txt`) keep
 working normally.
 
+#### WSL2 network restriction (proxy + network namespace)
+
+On WSL2, systemd's `IPAddressDeny`/`IPAddressAllow` properties are silently
+ignored because cgroup BPF-based IP filtering does not work under the WSL2
+systemd integration. The proxy starts and `HTTPS_PROXY` is set, but the
+agent can bypass it by connecting directly.
+
+To enforce network restriction on WSL2, use a **network namespace** so the
+agent can only reach the proxy:
+
+```bash
+# One-time setup (requires sudo, idempotent)
+sudo scripts/wsl2-netns-setup.sh
+```
+
+Then run the proxy on `10.200.0.1:7890` (host namespace) and launch the
+agent inside the namespace:
+
+```bash
+sudo ip netns exec agentns sudo -u "$USER" env \
+  HTTPS_PROXY=http://10.200.0.1:7890 \
+  HTTP_PROXY=http://10.200.0.1:7890 \
+  NO_PROXY=localhost,127.0.0.1 \
+  jailrun claude
+```
+
+This is kernel-enforced and cannot be bypassed from inside the namespace.
+
+When the `agentns` namespace exists, jailrun automatically detects it and:
+- Binds the proxy to `10.200.0.1:7890` instead of `127.0.0.1`
+- Launches the agent inside the namespace via `sudo ip netns exec`
+
+So after running the setup script, a normal `jailrun claude` will use the
+namespace automatically. To avoid sudo password prompts, add a sudoers entry:
+
+```
+%users ALL=(root) NOPASSWD: /usr/sbin/ip netns exec agentns *
+```
+
+Out of scope: jailrun does not manage the namespace lifecycle. Handle setup
+and teardown in your dotfiles or systemd units.
+
 ## Troubleshooting
 
 ### "AWS credential export failed"

--- a/README.md
+++ b/README.md
@@ -140,14 +140,10 @@ This is kernel-enforced and cannot be bypassed from inside the namespace.
 
 When the `agentns` namespace exists, jailrun automatically detects it and:
 - Binds the proxy to `10.200.0.1` (ephemeral port) instead of `127.0.0.1`
-- Launches the agent inside the namespace via `sudo ip netns exec`
+- Launches the agent inside the namespace via `NetworkNamespacePath`
 
 So after running the setup script, a normal `jailrun claude` will use the
-namespace automatically. To avoid sudo password prompts, add a sudoers entry:
-
-```
-%users ALL=(root) NOPASSWD: /usr/sbin/ip netns exec agentns *
-```
+namespace automatically. No sudo is required at runtime.
 
 Out of scope: jailrun does not manage the namespace lifecycle. Handle setup
 and teardown in your dotfiles or systemd units.

--- a/lib/config.py
+++ b/lib/config.py
@@ -55,6 +55,33 @@ LIST_KEYS = {
 
 KNOWN_KEYS = set(DEFAULTS.keys())
 
+# Built-in proxy allow domains per agent (merged when proxy is enabled)
+BUILTIN_PROXY_DOMAINS: dict[str, list[str]] = {
+    "claude": [
+        "api.anthropic.com",
+        "statsig.anthropic.com",
+    ],
+    "codex": [
+        "chatgpt.com",
+        "ab.chatgpt.com",
+        "api.openai.com",
+    ],
+    "kiro-cli": [
+        "*.kiro.dev",
+        "q.us-east-1.amazonaws.com",
+        "q.eu-central-1.amazonaws.com",
+        "desktop-release.q.us-east-1.amazonaws.com",
+        "cognito-identity.us-east-1.amazonaws.com",
+        "oidc.ap-northeast-1.amazonaws.com",
+        "client-telemetry.us-east-1.amazonaws.com",
+    ],
+}
+BUILTIN_PROXY_DOMAINS_COMMON: list[str] = [
+    "github.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+]
+
 DEFAULT_TOML = """\
 # jailrun config (TOML format)
 # Docs: https://github.com/ikeisuke/jailrun
@@ -213,6 +240,17 @@ def resolve_config(app: str = "", directory: str = "") -> dict:
             f'Invalid keychain_profile: "{kp}". '
             f"Must be one of: {', '.join(sorted(VALID_KEYCHAIN_PROFILES))}"
         )
+
+    # Merge built-in proxy domains (common + per-agent)
+    if result.get("proxy_enabled"):
+        builtin = list(BUILTIN_PROXY_DOMAINS_COMMON)
+        if app and app in BUILTIN_PROXY_DOMAINS:
+            builtin.extend(BUILTIN_PROXY_DOMAINS[app])
+        existing = set(result.get("proxy_allow_domains", []))
+        for d in builtin:
+            if d not in existing:
+                result.setdefault("proxy_allow_domains", []).append(d)
+                existing.add(d)
 
     return result
 

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -27,12 +27,10 @@ _setup_sandbox() {
     echo '-p AmbientCapabilities='
     echo '-p RestrictSUIDSGID=yes'
     echo '-p LockPersonality=yes'
-    # Device restrictions
-    echo '-p PrivateDevices=no'
-    echo '-p DevicePolicy=closed'
-    echo '-p DeviceAllow=/dev/null rw'
-    echo '-p DeviceAllow=/dev/random r'
-    echo '-p DeviceAllow=/dev/urandom r'
+    # Device restrictions — PrivateDevices=yes creates a minimal /dev with
+    # properly mounted devpts (ptmxmode=666), allowing PTY allocation for
+    # child processes (e.g. lefthook → biome).
+    echo '-p PrivateDevices=yes'
     # Process and IPC isolation
     echo '-p PrivateUsers=yes'
     echo '-p PrivateMounts=yes'
@@ -166,16 +164,29 @@ _setup_sandbox() {
 # Generate systemd EnvironmentFile from env-spec
 _build_systemd_envfile() {
   local _envfile="$_tmpdir/env-systemd"
+  local _envfile_sh="$_tmpdir/env-systemd.sh"
   while IFS= read -r _line; do
     case "$_line" in
       SET\ *) printf '%s\n' "${_line#SET }" ;;
     esac
   done < "$_tmpdir/env-spec" > "$_envfile"
+  # Shell-compatible version with quoted values (for namespace mode)
+  while IFS='=' read -r _key _val; do
+    [ -n "$_key" ] && printf "export %s='%s'\n" "$_key" "$(printf '%s' "$_val" | sed "s/'/'\\\\''/g")"
+  done < "$_envfile" > "$_envfile_sh"
 }
 
 # Write sandbox exec command to stdout (appended to exec.sh)
 _build_sandbox_exec() {
   _build_systemd_envfile
+
+  # When network namespace is active, wrap with ip netns exec
+  if [ -n "${_NETNS:-}" ]; then
+    printf 'exec sudo ip netns exec %s sudo -u "%s" \\\n' "$_NETNS" "$(id -un)"
+    printf '  sh -c '\''. "%s/env-systemd.sh"; printf "\\033]0;jailrun %%s\\007" "${1##*/}"; exec "$@"'\'' _ "$@"\n' "$_tmpdir"
+    return
+  fi
+
   # --pty allocates a new PTY, so set OSC title from inside the PTY
   printf 'exec systemd-run \\\n'
   printf '  --user --pty --wait --collect --same-dir \\\n'

--- a/lib/platform/sandbox-linux-systemd.sh
+++ b/lib/platform/sandbox-linux-systemd.sh
@@ -46,6 +46,10 @@ _setup_sandbox() {
       echo '-p IPAddressAllow=127.0.0.0/8'
       echo '-p IPAddressAllow=::1/128'
     fi
+    # When network namespace exists, join it (kernel-enforced network isolation)
+    if [ -n "${_NETNS:-}" ]; then
+      echo "-p NetworkNamespacePath=/run/netns/$_NETNS"
+    fi
     # Filesystem
     if [ -z "${_APPARMOR_PROFILE_LOADED:-}" ]; then
       echo '-p ProtectSystem=strict'
@@ -164,28 +168,16 @@ _setup_sandbox() {
 # Generate systemd EnvironmentFile from env-spec
 _build_systemd_envfile() {
   local _envfile="$_tmpdir/env-systemd"
-  local _envfile_sh="$_tmpdir/env-systemd.sh"
   while IFS= read -r _line; do
     case "$_line" in
       SET\ *) printf '%s\n' "${_line#SET }" ;;
     esac
   done < "$_tmpdir/env-spec" > "$_envfile"
-  # Shell-compatible version with quoted values (for namespace mode)
-  while IFS='=' read -r _key _val; do
-    [ -n "$_key" ] && printf "export %s='%s'\n" "$_key" "$(printf '%s' "$_val" | sed "s/'/'\\\\''/g")"
-  done < "$_envfile" > "$_envfile_sh"
 }
 
 # Write sandbox exec command to stdout (appended to exec.sh)
 _build_sandbox_exec() {
   _build_systemd_envfile
-
-  # When network namespace is active, wrap with ip netns exec
-  if [ -n "${_NETNS:-}" ]; then
-    printf 'exec sudo ip netns exec %s sudo -u "%s" \\\n' "$_NETNS" "$(id -un)"
-    printf '  sh -c '\''. "%s/env-systemd.sh"; printf "\\033]0;jailrun %%s\\007" "${1##*/}"; exec "$@"'\'' _ "$@"\n' "$_tmpdir"
-    return
-  fi
 
   # --pty allocates a new PTY, so set OSC title from inside the PTY
   printf 'exec systemd-run \\\n'

--- a/lib/proxy.py
+++ b/lib/proxy.py
@@ -185,11 +185,11 @@ def handle_client(
             pass
 
 
-def run_proxy(allowed_domains: set[str], port: int = 0) -> None:
+def run_proxy(allowed_domains: set[str], port: int = 0, bind: str = "127.0.0.1") -> None:
     """Start the proxy server."""
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.bind(("127.0.0.1", port))
+    server.bind((bind, port))
     server.listen(128)
 
     actual_port = server.getsockname()[1]
@@ -198,7 +198,8 @@ def run_proxy(allowed_domains: set[str], port: int = 0) -> None:
     print(actual_port, flush=True)
 
     logger.info(
-        "proxy listening on 127.0.0.1:%d, allowed: %s",
+        "proxy listening on %s:%d, allowed: %s",
+        bind,
         actual_port,
         ", ".join(sorted(allowed_domains)),
     )
@@ -231,6 +232,11 @@ def main() -> None:
         default=0,
         help="Port to listen on (0 = ephemeral)",
     )
+    parser.add_argument(
+        "--bind",
+        default="127.0.0.1",
+        help="Address to bind to (default: 127.0.0.1)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -244,7 +250,7 @@ def main() -> None:
         logger.error("no allowed domains specified")
         sys.exit(1)
 
-    run_proxy(allowed, args.port)
+    run_proxy(allowed, args.port, args.bind)
 
 
 if __name__ == "__main__":

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -325,11 +325,9 @@ _start_proxy() {
 
   # Detect network namespace — if agentns exists, bind to veth-host IP
   _proxy_bind="127.0.0.1"
-  _proxy_port_arg=""
   _NETNS=""
   if ip netns list 2>/dev/null | grep -qw agentns; then
     _proxy_bind="10.200.0.1"
-    _proxy_port_arg="--port 7890"
     _NETNS="agentns"
   fi
 
@@ -338,7 +336,7 @@ _start_proxy() {
   mkfifo "$_fifo"
   _proxy_log="/dev/null"
   [ "${AGENT_SANDBOX_DEBUG:-}" = "1" ] && _proxy_log="$_tmpdir/proxy.log"
-  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" --bind "$_proxy_bind" $_proxy_port_arg > "$_fifo" 2>"$_proxy_log" &
+  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" --bind "$_proxy_bind" > "$_fifo" 2>"$_proxy_log" &
   _proxy_pid=$!
   read -r _proxy_port < "$_fifo"
   rm -f "$_fifo"

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -385,11 +385,6 @@ credential_guard_sandbox_exec() {
       printf 'exec "%s" "$@"\n' "$_tmpdir/exec.sh"
     } > "$_proxy_script"
     chmod +x "$_proxy_script"
-    # Also append to env-systemd.sh for namespace mode
-    if [ -f "$_tmpdir/env-systemd.sh" ]; then
-      printf "export HTTPS_PROXY='http://%s:%s'\n" "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT" >> "$_tmpdir/env-systemd.sh"
-      printf "export HTTP_PROXY='http://%s:%s'\n" "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT" >> "$_tmpdir/env-systemd.sh"
-    fi
   fi
 
   if [ -n "$_sandbox_cmd" ]; then

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -45,12 +45,11 @@ done
 
 _SANDBOX_ALLOW_WRITE_PATHS=""
 # Cross-platform paths: create if missing (safe to mkdir)
-# Note: ~/.kiro and ~/.local/share are intentionally NOT listed here; they are
-# moved to _SANDBOX_ALLOW_WRITE_LOCK_PATHS below because kiro-cli requires
-# the lock (k) AppArmor permission for SQLite / JSON file_lock (Issue #78).
+# Note: ~/.kiro, ~/.local/share, ~/.codex are intentionally NOT listed here;
+# they are moved to _SANDBOX_ALLOW_WRITE_LOCK_PATHS below because they use
+# SQLite WAL which requires the lock (k) AppArmor permission (Issue #78).
 for _p in \
   "$HOME/.claude" \
-  "$HOME/.codex" \
   "$HOME/.gemini" \
   "$HOME/.local/state" \
   "$HOME/.cache" \
@@ -130,6 +129,7 @@ done
 # Future abstraction candidate: SANDBOX_EXTRA_LOCK_PATHS env var (recorded in
 # Construction Phase decisions.md).
 for _p in \
+  "$HOME/.codex" \
   "$HOME/.kiro" \
   "$HOME/.local/share"
 do
@@ -323,10 +323,22 @@ _start_proxy() {
   # Convert space-separated to comma-separated for proxy.py
   _domains=$(printf '%s' "$PROXY_ALLOW_DOMAINS" | tr ' ' ',')
 
+  # Detect network namespace — if agentns exists, bind to veth-host IP
+  _proxy_bind="127.0.0.1"
+  _proxy_port_arg=""
+  _NETNS=""
+  if ip netns list 2>/dev/null | grep -qw agentns; then
+    _proxy_bind="10.200.0.1"
+    _proxy_port_arg="--port 7890"
+    _NETNS="agentns"
+  fi
+
   # Start proxy, capture port from first stdout line via FIFO
   _fifo="$_tmpdir/proxy-port"
   mkfifo "$_fifo"
-  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" > "$_fifo" &
+  _proxy_log="/dev/null"
+  [ "${AGENT_SANDBOX_DEBUG:-}" = "1" ] && _proxy_log="$_tmpdir/proxy.log"
+  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" --bind "$_proxy_bind" $_proxy_port_arg > "$_fifo" 2>"$_proxy_log" &
   _proxy_pid=$!
   read -r _proxy_port < "$_fifo"
   rm -f "$_fifo"
@@ -336,9 +348,10 @@ _start_proxy() {
     return
   fi
 
-  echo "[$_WRAPPER_NAME] proxy: 127.0.0.1:$_proxy_port (pid $_proxy_pid)" >&2
+  echo "[$_WRAPPER_NAME] proxy: $_proxy_bind:$_proxy_port (pid $_proxy_pid)" >&2
   _PROXY_PORT="$_proxy_port"
   _PROXY_PID="$_proxy_pid"
+  _PROXY_BIND="$_proxy_bind"
 }
 
 # ============================================================
@@ -369,11 +382,16 @@ credential_guard_sandbox_exec() {
     _proxy_script="$_tmpdir/exec-proxy.sh"
     {
       echo '#!/bin/sh'
-      printf 'export HTTPS_PROXY="http://127.0.0.1:%s"\n' "$_PROXY_PORT"
-      printf 'export HTTP_PROXY="http://127.0.0.1:%s"\n' "$_PROXY_PORT"
+      printf 'export HTTPS_PROXY="http://%s:%s"\n' "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT"
+      printf 'export HTTP_PROXY="http://%s:%s"\n' "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT"
       printf 'exec "%s" "$@"\n' "$_tmpdir/exec.sh"
     } > "$_proxy_script"
     chmod +x "$_proxy_script"
+    # Also append to env-systemd.sh for namespace mode
+    if [ -f "$_tmpdir/env-systemd.sh" ]; then
+      printf "export HTTPS_PROXY='http://%s:%s'\n" "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT" >> "$_tmpdir/env-systemd.sh"
+      printf "export HTTP_PROXY='http://%s:%s'\n" "${_PROXY_BIND:-127.0.0.1}" "$_PROXY_PORT" >> "$_tmpdir/env-systemd.sh"
+    fi
   fi
 
   if [ -n "$_sandbox_cmd" ]; then

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -316,6 +316,24 @@ if ip netns list 2>/dev/null | grep -qw agentns; then
   _NETNS="agentns"
 fi
 
+# Fail-fast guard: NetworkNamespacePath requires systemd >= 243.
+# Older systemd silently drops the property and the agent would run in the
+# host namespace while the proxy is bound to 10.200.0.1 — a fail-open of the
+# network restriction. Refuse to start instead of pretending to be isolated.
+if [ -n "$_NETNS" ] && command -v systemd-run >/dev/null 2>&1; then
+  _sd_ver=$(systemd-run --version 2>/dev/null | awk 'NR==1 {print $2}')
+  case "$_sd_ver" in
+    ''|*[!0-9]*) : ;;
+    *)
+      if [ "$_sd_ver" -lt 243 ]; then
+        echo "[$_WRAPPER_NAME] error: agentns requires systemd >= 243 for NetworkNamespacePath (current: $_sd_ver)" >&2
+        echo "[$_WRAPPER_NAME] error: older systemd silently ignores it, which would fail-open the network restriction" >&2
+        exit 1
+      fi
+      ;;
+  esac
+fi
+
 _start_proxy() {
   # Read proxy config from TOML (already eval'd into shell vars)
   if [ "${PROXY_ENABLED:-false}" != "true" ] && [ "${PROXY_ENABLED:-false}" != "1" ]; then

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -310,6 +310,12 @@ _build_exec_script() {
 # Section 5: Proxy management
 # ============================================================
 
+# Detect network namespace early (before _setup_sandbox generates systemd-props)
+_NETNS=""
+if ip netns list 2>/dev/null | grep -qw agentns; then
+  _NETNS="agentns"
+fi
+
 _start_proxy() {
   # Read proxy config from TOML (already eval'd into shell vars)
   if [ "${PROXY_ENABLED:-false}" != "true" ] && [ "${PROXY_ENABLED:-false}" != "1" ]; then
@@ -323,12 +329,10 @@ _start_proxy() {
   # Convert space-separated to comma-separated for proxy.py
   _domains=$(printf '%s' "$PROXY_ALLOW_DOMAINS" | tr ' ' ',')
 
-  # Detect network namespace — if agentns exists, bind to veth-host IP
+  # Bind to veth-host IP when network namespace is active
   _proxy_bind="127.0.0.1"
-  _NETNS=""
-  if ip netns list 2>/dev/null | grep -qw agentns; then
+  if [ -n "$_NETNS" ]; then
     _proxy_bind="10.200.0.1"
-    _NETNS="agentns"
   fi
 
   # Start proxy, capture port from first stdout line via FIFO

--- a/scripts/wsl2-netns-setup.sh
+++ b/scripts/wsl2-netns-setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Setup network namespace for jailrun on WSL2.
+# Usage: sudo scripts/wsl2-netns-setup.sh
+# Idempotent — safe to run multiple times.
+#
+# Creates a network namespace "agentns" with a veth pair so that
+# processes inside can only reach the proxy at 10.200.0.1:7890.
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "error: must be run as root (sudo $0)" >&2
+  exit 1
+fi
+
+NS="agentns"
+VETH_HOST="veth-host"
+VETH_AGENT="veth-agent"
+HOST_IP="10.200.0.1"
+AGENT_IP="10.200.0.2"
+CIDR="24"
+PROXY_PORT="7890"
+
+# --- Namespace ---
+if ip netns list | grep -qw "$NS"; then
+  echo "[netns] '$NS' already exists, skipping creation"
+else
+  ip netns add "$NS"
+  echo "[netns] created '$NS'"
+fi
+
+# --- Veth pair ---
+if ip link show "$VETH_HOST" &>/dev/null; then
+  echo "[veth] '$VETH_HOST' already exists, skipping"
+else
+  ip link add "$VETH_HOST" type veth peer name "$VETH_AGENT"
+  ip link set "$VETH_AGENT" netns "$NS"
+  echo "[veth] created $VETH_HOST <-> $VETH_AGENT"
+fi
+
+# --- Host side ---
+if ! ip addr show "$VETH_HOST" | grep -q "$HOST_IP"; then
+  ip addr add "$HOST_IP/$CIDR" dev "$VETH_HOST"
+fi
+ip link set "$VETH_HOST" up
+
+# --- Agent side (inside namespace) ---
+ip netns exec "$NS" ip addr add "$AGENT_IP/$CIDR" dev "$VETH_AGENT" 2>/dev/null || true
+ip netns exec "$NS" ip link set lo up
+ip netns exec "$NS" ip link set "$VETH_AGENT" up
+ip netns exec "$NS" ip route replace default via "$HOST_IP"
+
+# --- iptables (inside namespace) ---
+ip netns exec "$NS" iptables -P OUTPUT DROP
+ip netns exec "$NS" iptables -F OUTPUT
+ip netns exec "$NS" iptables -A OUTPUT -o lo -j ACCEPT
+ip netns exec "$NS" iptables -A OUTPUT -p tcp -d "$HOST_IP" --dport "$PROXY_PORT" -j ACCEPT
+
+echo "[done] namespace '$NS' ready — proxy expected at $HOST_IP:$PROXY_PORT"

--- a/scripts/wsl2-netns-setup.sh
+++ b/scripts/wsl2-netns-setup.sh
@@ -4,7 +4,7 @@
 # Idempotent — safe to run multiple times.
 #
 # Creates a network namespace "agentns" with a veth pair so that
-# processes inside can only reach the proxy at 10.200.0.1:7890.
+# processes inside can only reach the proxy at 10.200.0.1.
 
 set -euo pipefail
 
@@ -19,7 +19,6 @@ VETH_AGENT="veth-agent"
 HOST_IP="10.200.0.1"
 AGENT_IP="10.200.0.2"
 CIDR="24"
-PROXY_PORT="7890"
 
 # --- Namespace ---
 if ip netns list | grep -qw "$NS"; then
@@ -54,6 +53,6 @@ ip netns exec "$NS" ip route replace default via "$HOST_IP"
 ip netns exec "$NS" iptables -P OUTPUT DROP
 ip netns exec "$NS" iptables -F OUTPUT
 ip netns exec "$NS" iptables -A OUTPUT -o lo -j ACCEPT
-ip netns exec "$NS" iptables -A OUTPUT -p tcp -d "$HOST_IP" --dport "$PROXY_PORT" -j ACCEPT
+ip netns exec "$NS" iptables -A OUTPUT -p tcp -d "$HOST_IP" -j ACCEPT
 
-echo "[done] namespace '$NS' ready — proxy expected at $HOST_IP:$PROXY_PORT"
+echo "[done] namespace '$NS' ready — proxy binds to $HOST_IP (any port)"

--- a/tests/sandbox_linux_systemd.bats
+++ b/tests/sandbox_linux_systemd.bats
@@ -93,10 +93,7 @@ run_setup_sandbox() {
 @test "generates device restrictions" {
   run_setup_sandbox
   [ "$status" -eq 0 ]
-  [[ "$output" == *"DevicePolicy=closed"* ]]
-  [[ "$output" == *"DeviceAllow=/dev/null rw"* ]]
-  [[ "$output" == *"DeviceAllow=/dev/random r"* ]]
-  [[ "$output" == *"DeviceAllow=/dev/urandom r"* ]]
+  [[ "$output" == *"PrivateDevices=yes"* ]]
 }
 
 @test "generates kernel protection properties" {


### PR DESCRIPTION
## Summary

On WSL2, systemd's `IPAddressDeny` is silently ignored (cgroup BPF unavailable).
This PR enforces network restriction using a network namespace (`agentns`) +
`NetworkNamespacePath` systemd property, preserving all existing sandbox hardening.

## Changes

- `proxy.py`: add `--bind` option
- `sandbox.sh`: auto-detect `agentns`, bind proxy to `10.200.0.1` (ephemeral port)
- `sandbox-linux-systemd.sh`: emit `NetworkNamespacePath` when namespace exists
- `scripts/wsl2-netns-setup.sh`: idempotent namespace setup script (requires sudo)
- `config.py`: built-in proxy allow domains per agent (common + per-agent merged)
- Proxy logs suppressed unless `AGENT_SANDBOX_DEBUG=1`
- **Out-of-scope but bundled**: `sandbox-linux-systemd.sh` switches device restrictions from `PrivateDevices=no` + `DevicePolicy=closed` + individual `DeviceAllow` lines to `PrivateDevices=yes` so child processes (lefthook → biome) can allocate PTY via a minimal `/dev` with `devpts(ptmxmode=666)`. Test assertions in `tests/sandbox_linux_systemd.bats` are updated accordingly.
- **Fail-open guard (post-review fix-up)**: `sandbox.sh` refuses to start when `agentns` is detected but the running systemd is older than 243 (older systemd silently drops `NetworkNamespacePath`, which would put the agent back in the host namespace while the user assumes isolation).

## Known follow-ups (tracked for v0.3.8 AI-DLC cycle)

The following error-handling robustness items surfaced in pre-merge review and are intentionally deferred to a follow-up cycle:

- Proxy bind failure under partial namespace setup currently hard-fails the wrapper. Should validate `veth-host`/`10.200.0.1` reachability and either preflight-check or fall back to loopback with explicit warning.
- Proxy stderr is sent to `/dev/null` unless `AGENT_SANDBOX_DEBUG=1`. Should always capture to a file by default so bind/CONNECT/DNS errors are diagnosable in normal runs.
- `10.200.0.1` is hard-coded in both `wsl2-netns-setup.sh` and `sandbox.sh`. Should derive dynamically from `ip addr show veth-host` or share a constant.
- `scripts/wsl2-netns-setup.sh` lacks a teardown counterpart; `iptables -P INPUT DROP` is not set inside the namespace.
- `BUILTIN_PROXY_DOMAINS` is a hard-coded table; should evolve toward a config-file overlay and add a `gemini` entry once verified.

## Usage

```bash
sudo scripts/wsl2-netns-setup.sh   # one-time setup
jailrun claude                      # auto-detects namespace
```

No sudo required at runtime. Multiple instances can run simultaneously (ephemeral ports).
