### PR TITLE
v0.4.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,8 +11,10 @@ Issue #86 で defer されていた「namespace 内 OUTPUT iptables ルールが
 - **`lib/netns-const.sh`**（Unit 001 / Issue #86 ストーリー1）: 既存 4 変数に加え `JAILRUN_PROXY_PORT_RANGE_START` (`60000`) / `JAILRUN_PROXY_PORT_RANGE_END` (`60099`) を変数代入のみで追加（副作用なし不変条件を維持）。setup スクリプト / proxy.py 双方から source できる単一 SoT として機能。
 - **`scripts/wsl2-netns-setup.sh`**（Unit 001 / ストーリー1）: consumer 側で SoT 範囲値の整数 / `1..65535` / `START <= END` / 先頭ゼロ拒否を検証して fail-fast で exit 1。OUTPUT ACCEPT ルールを `-A OUTPUT -p tcp -d "$HOST_IP" --dport "$START":"$END" -j ACCEPT` に変更し、host IP の範囲外 TCP ポートをデフォルト DROP に閉じ込め。完了メッセージも「proxy binds to <HOST_IP> ports <START>:<END>」へ更新。
 - **`lib/netns_const_loader.py`**（Unit 002 / ストーリー2 / 新規）: SoT 読取の単一公開 API として関数ファサード `load_port_range()` を提供。SoT パスは `__file__` 相対固定で runtime 上書き経路を持たず（環境変数依存撤廃）、`sh -c` は位置引数化で injection 排除。失敗時は `RuntimeError` に resolved 絶対パスを必ず含める契約。
-- **`lib/proxy.py`**（Unit 002 / ストーリー2）: `run_proxy()` に範囲制約を追加。`--port N` で N が範囲外なら `RuntimeError` で fail-closed、`--port 0`（既定）は OS エフェメラル割当へのフォールバックを廃止し範囲内を昇順に手動 bind 試行。`main()` で `RuntimeError` を捕捉して stderr + exit 1。
-- **`lib/sandbox.sh`**（Unit 003 / ストーリー3）: `_start_proxy()` のコメントを SoT 範囲依存に更新（実装ロジックは無改修、Unit 002 の proxy.py 内部完結のため）。
+- **`lib/proxy.py`**（Unit 002 / ストーリー2）: `--enforce-port-range` フラグを新設し、フラグが立っている場合のみ SoT 範囲制約を適用（`--port N` で N が範囲外なら `RuntimeError` で fail-closed、`--port 0` は範囲内を昇順に手動 bind 試行）。フラグなしでは v0.4.0 と同じ OS エフェメラル既定動作を維持し、netns 非使用時の並列実行可用性回帰を防ぐ（PR #89 pre-merge review #2 への対応）。`main()` で `RuntimeError` を捕捉して stderr + exit 1。
+- **`lib/sandbox.sh`**（Unit 002 / PR #89 review #2 対応）: `_start_proxy()` が `_NETNS` 設定時のみ `--enforce-port-range` を proxy.py に渡すように改修（非 netns モードでは v0.4.0 同等の挙動）。
+- **`Makefile`**（Unit 002 / PR #89 review #1 対応）: `lib/netns_const_loader.py` を install 対象に追加。proxy.py の import 依存が installed 環境でも解決されるようにする。
+- **`lib/sandbox.sh`**（Unit 003 / ストーリー3）: `_start_proxy()` のコメントを SoT 範囲依存に更新（v0.4.1 PR レビューで `--enforce-port-range` フラグ送出の実装変更も追加）。
 
 #### Tests
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,49 @@
 # Change History
 
+## v0.4.1 — WSL2 netns OUTPUT ポート範囲限定（defense-in-depth 強化）（patch リリース） (2026-05-16)
+
+Issue #86 で defer されていた「namespace 内 OUTPUT iptables ルールが宛先 host IP のみで宛先ポートを限定していない」defense-in-depth gap を解消する patch リリース。`lib/netns-const.sh` に proxy bind 想定ポート範囲の単一 SoT (`JAILRUN_PROXY_PORT_RANGE_START` / `_END`) を追加し、`scripts/wsl2-netns-setup.sh` の OUTPUT ACCEPT ルールを `--dport START:END` に限定。`lib/proxy.py` の bind 経路（`--port N` / `--port 0`）を Unit 001 SoT の範囲内に閉じ込めるよう改修し、Python loader (`lib/netns_const_loader.py`) を新設して setup スクリプトと proxy が同じ SoT を消費する単一窓口を提供。N=10 並列 × 5 反復の可用性テストで範囲幅 60000-60099 を確定。「実行時 sudo 不要」「setup 一回」という v0.4.0 設計特性は維持。
+
+### Changes
+
+#### Production
+
+- **`lib/netns-const.sh`**（Unit 001 / Issue #86 ストーリー1）: 既存 4 変数に加え `JAILRUN_PROXY_PORT_RANGE_START` (`60000`) / `JAILRUN_PROXY_PORT_RANGE_END` (`60099`) を変数代入のみで追加（副作用なし不変条件を維持）。setup スクリプト / proxy.py 双方から source できる単一 SoT として機能。
+- **`scripts/wsl2-netns-setup.sh`**（Unit 001 / ストーリー1）: consumer 側で SoT 範囲値の整数 / `1..65535` / `START <= END` / 先頭ゼロ拒否を検証して fail-fast で exit 1。OUTPUT ACCEPT ルールを `-A OUTPUT -p tcp -d "$HOST_IP" --dport "$START":"$END" -j ACCEPT` に変更し、host IP の範囲外 TCP ポートをデフォルト DROP に閉じ込め。完了メッセージも「proxy binds to <HOST_IP> ports <START>:<END>」へ更新。
+- **`lib/netns_const_loader.py`**（Unit 002 / ストーリー2 / 新規）: SoT 読取の単一公開 API として関数ファサード `load_port_range()` を提供。SoT パスは `__file__` 相対固定で runtime 上書き経路を持たず（環境変数依存撤廃）、`sh -c` は位置引数化で injection 排除。失敗時は `RuntimeError` に resolved 絶対パスを必ず含める契約。
+- **`lib/proxy.py`**（Unit 002 / ストーリー2）: `run_proxy()` に範囲制約を追加。`--port N` で N が範囲外なら `RuntimeError` で fail-closed、`--port 0`（既定）は OS エフェメラル割当へのフォールバックを廃止し範囲内を昇順に手動 bind 試行。`main()` で `RuntimeError` を捕捉して stderr + exit 1。
+- **`lib/sandbox.sh`**（Unit 003 / ストーリー3）: `_start_proxy()` のコメントを SoT 範囲依存に更新（実装ロジックは無改修、Unit 002 の proxy.py 内部完結のため）。
+
+#### Tests
+
+- **`tests/wsl2_netns_output_range.bats`**（Unit 001 / 新規 / 静的 7 件 + root-gated 動作 4 件）: SoT 公開キーが POSIX sh から source 可能 / 副作用なし維持 / setup OUTPUT に `--dport` 制約 / 整数検証ロジック存在 / `bash -n` clean / 不変条件成立 / fixture を使った非整数・先頭ゼロ拒否。動作テストは B1（iptables 展開直接確認）+ B2（範囲外 timeout）+ B3（範囲内成功）+ B4（再 setup 冪等性）を triangulation で同時実行。Unit 002 で S7 を共通テストベクトル消費に拡張。
+- **`tests/proxy_port_range.bats`**（Unit 002 / 新規 / 3 件）: CLI level の挙動ベース検証 — 範囲下限未満 fail-closed / 上限超 fail-closed / port=0 範囲内 bind。import grep は実装詳細結合のため明示的に対象外。
+- **`tests/proxy_parallel_availability.bats`**（Unit 002 / 新規 / N=10 × 5 反復）: loopback で 50 並列 bind 試行をすべて範囲内かつ重複なしで成功させる可用性テスト。`PIDS` / `STDOUT_FILES` / `STDERR_FILES` / `PORTS` を同じ添字で管理し、spawn → readiness → kill → wait → verify の決定的シーケンスを各反復で実行。
+- **`tests/port_range_invalid_vectors.py`**（Unit 002 / 新規）: Python 単一正準の異常ケース集合 9 件（先頭ゼロ / 非数 / 範囲外 / `START > END` / 空文字）。`tests/test_netns_const_loader.py`（Python loader 単体）と `tests/wsl2_netns_output_range.bats` の S7 拡張（setup スクリプト consumer 検証）が **同じファイルを直接読む** ことで Python / shell 検証ロジックの drift を物理的に排除。
+- **`tests/test_netns_const_loader.py`**（Unit 002 / 新規）: `load_port_range()` の happy path / SoT パス不在 / 共通異常ベクトル全件 / エラーメッセージへの resolved path 包含 / 公開 API 表面（`__all__` が関数 1 本のみ）を検証。モンキーパッチで `_resolve_netns_const_path` を差し替え、環境変数依存ゼロでテスト可能。
+- **`tests/test_proxy.py`**（Unit 002 / 既存に追加 / `TestBindInRange` 3 件 + `TestRunProxyPortRange` 2 件）: `_bind_in_range()` の単体（範囲内 bind / 順序通り次候補に skip / 範囲枯渇時の `RuntimeError`）と `run_proxy()` の範囲外 fail-closed を分離検証。
+
+#### Documentation
+
+- **`README.md`**（Unit 003 / ストーリー3）: WSL2 netns セクションに defense-in-depth の意味 + 保証範囲（`10.200.0.1:60000..60099` のみ）+ 現行 OUTPUT ルール確認コマンド（`sudo ip netns exec agentns iptables -L OUTPUT -v -n | grep dpts`）+ v0.4.0 setup 済みユーザー向け再 setup 手順 + SoT 変更時の追従モデル（再 setup 必須 / 未再 setup 時は旧 iptables 継続、proxy 自体は起動するが agentns から到達不可で実通信が失敗する runtime fail-closed）を追記。
+- **`scripts/wsl2-netns-setup.sh`**（Unit 001）: 冒頭コメントを「proxy at 10.200.0.1 on the configured TCP port range (JAILRUN_PROXY_PORT_RANGE_START:..._END)」へ更新。
+- **`lib/proxy.py`**（Unit 003）: docstring に「v0.4.1 から bind port は SoT 範囲内に閉じ込められる」「`--port N` 範囲外は fail-closed」「`--port 0` は OS エフェメラルへフォールバックしない」を明記。
+- **`lib/sandbox.sh`**（Unit 003）: `_start_proxy()` の bind 周辺コメントに SoT 範囲依存の意図を追記。
+
+#### Build
+
+- **`bin/jailrun`**（Unit 003）: `VERSION` 定数を `0.4.0` → `0.4.1` に更新。
+
+### Review
+
+- **Unit 001**: 計画 codex 3R / 設計 codex 3R / コード codex 2R / 統合 codex 2R = 全 10 round clean、全 7 指摘 resolved。SoT 検証ロジックの先頭ゼロ拒否強化（コードレビュー R1 #1）、SoT 格納方式の明示的固定（計画 R1 #2）、Unit 002 consumption contract の確定（計画 R1 #3）、ドメインモデルのルール分割（設計 R1 #1）等を反映。
+- **Unit 002**: 計画 codex 2R / 設計 codex 3R / コード codex 2R / 統合 codex 1R = 全 8 round clean、全 12 指摘 resolved。`sh -c` injection 排除（コード R1 #1）、runtime SoT 上書き経路撤廃（コード R1 #2、`JAILRUN_LIB` 環境変数依存削除）、テスト責務の分離（コード R1 #3）、共通テストベクトル正準の一元化（設計 R2 #2）等を反映。
+- **Unit 003**: 計画 codex 3R 完了（R1: 4 指摘 / R2: 1 指摘 / R3: clean）、全 5 指摘 resolved（SoT 変更時追従モデルの README 明文化必須化が高重要度）。
+
+### Backlog 繰越
+
+- 現時点で v0.4.1 サイクル発生の指摘はすべて resolved（繰越なし）。Issue #86 はサイクル成果物で完全クローズ予定。
+
 ## v0.4.0 — WSL2 netns 安全性強化 + proxy エラーハンドリング堅牢化 + allow domains 整理（minor リリース） (2026-05-15)
 
 v0.3.7 で main にマージ済みの WSL2 network namespace 機能（`agentns` モード）について、運用ライフサイクル・proxy 起動失敗時のリーク・allow domains の設定方式不整合を解消する minor リリース。`agentns` 削除手順を公式化し、起動失敗時の proxy リーク（PID 取り残し / TCP ポートホールド）を構造的に塞ぎ、`BUILTIN_PROXY_DOMAINS` を agent 別の単一テーブルに整理した。

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ install:
 	install -m 644 lib/config_cli.py $(PREFIX)/lib/jailrun/config_cli.py
 	install -m 644 lib/config_migrate.py $(PREFIX)/lib/jailrun/config_migrate.py
 	install -m 644 lib/proxy.py $(PREFIX)/lib/jailrun/proxy.py
+	install -m 644 lib/netns_const_loader.py $(PREFIX)/lib/jailrun/netns_const_loader.py
 
 test:
 	bats tests/

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ When the `agentns` namespace exists, jailrun automatically detects it and:
 - Binds the proxy to `10.200.0.1` on a port inside the SoT range defined in
   `lib/netns-const.sh` (`JAILRUN_PROXY_PORT_RANGE_START..END`, currently
   `60000..60099`) instead of `127.0.0.1` on an arbitrary OS-assigned port
+  (the proxy is invoked with `--enforce-port-range` only in this mode; plain
+  `127.0.0.1` launches keep using the OS ephemeral pool, see PR #89)
 - Launches the agent inside the namespace via `NetworkNamespacePath`
 
 So after running the setup script, a normal `jailrun claude` will use the

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ systemd integration. The proxy starts and `HTTPS_PROXY` is set, but the
 agent can bypass it by connecting directly.
 
 To enforce network restriction on WSL2, use a **network namespace** so the
-agent can only reach the proxy:
+agent can only reach the proxy on a **defined TCP port range**:
 
 ```bash
 # One-time setup (requires sudo, idempotent)
@@ -139,11 +139,53 @@ sudo scripts/wsl2-netns-setup.sh
 This is kernel-enforced and cannot be bypassed from inside the namespace.
 
 When the `agentns` namespace exists, jailrun automatically detects it and:
-- Binds the proxy to `10.200.0.1` (ephemeral port) instead of `127.0.0.1`
+- Binds the proxy to `10.200.0.1` on a port inside the SoT range defined in
+  `lib/netns-const.sh` (`JAILRUN_PROXY_PORT_RANGE_START..END`, currently
+  `60000..60099`) instead of `127.0.0.1` on an arbitrary OS-assigned port
 - Launches the agent inside the namespace via `NetworkNamespacePath`
 
 So after running the setup script, a normal `jailrun claude` will use the
 namespace automatically. No sudo is required at runtime.
+
+Since cycle v0.4.1, the namespace OUTPUT `iptables` rule is restricted to
+**TCP destination ports inside that range only** (defense-in-depth): the
+agent can no longer reach arbitrary services that happen to listen on
+`10.200.0.1` (for example a host-side SSH daemon or local dev server).
+
+**Verify the current OUTPUT rule** (must show a `dpts:60000:60099` range
+matching the SoT):
+
+```bash
+sudo ip netns exec agentns iptables -L OUTPUT -v -n | grep dpts
+# expected: ... dpts:60000:60099 ... ACCEPT
+```
+
+If the line is missing (no `dpts:` segment), you are still on the v0.4.0
+setup that allowed every host IP port. Re-run the setup to upgrade:
+
+```bash
+# Re-setup for users who installed under v0.4.0 or earlier
+sudo scripts/wsl2-netns-teardown.sh
+sudo scripts/wsl2-netns-setup.sh
+sudo ip netns exec agentns iptables -L OUTPUT -v -n | grep dpts   # confirm
+```
+
+jailrun does **not** auto-migrate the namespace at runtime (this would
+require sudo every launch); the manual re-setup above is the only path.
+
+#### SoT change follow-up contract
+
+If you ever change `JAILRUN_PROXY_PORT_RANGE_*` in `lib/netns-const.sh`,
+the existing namespace's `iptables` rule keeps the **old** range until you
+re-run the setup script — `sudo scripts/wsl2-netns-teardown.sh` followed
+by `sudo scripts/wsl2-netns-setup.sh`. The proxy (which reads the SoT at
+launch) will pick up the new range immediately, so without re-setup the
+proxy's bind range and the kernel's accept range diverge: the proxy
+process itself **does** start and bind successfully on the host side, but
+traffic from inside `agentns` to the proxy's new port is dropped by the
+old OUTPUT rule, so every CONNECT request times out. That is, the proxy
+stays unreachable from the sandbox until you re-setup — not a startup
+failure, a reachability failure at runtime.
 
 To remove the namespace, run the teardown script (also idempotent — safe
 to run when nothing exists or after a partially failed setup):

--- a/bin/jailrun
+++ b/bin/jailrun
@@ -13,7 +13,7 @@
 
 set -eu
 
-VERSION="0.4.0"
+VERSION="0.4.1"
 
 # resolve real path of $0 (macOS lacks readlink -f, use cd+pwd)
 _resolve_path() {

--- a/lib/netns-const.sh
+++ b/lib/netns-const.sh
@@ -9,3 +9,13 @@ JAILRUN_NETNS_HOST_IP="10.200.0.1"
 JAILRUN_NETNS_NAME="agentns"
 JAILRUN_NETNS_VETH_HOST="veth-host"
 JAILRUN_NETNS_VETH_AGENT="veth-agent"
+
+# proxy bind port range (single SoT). Closed interval [START, END]
+# matching the iptables --dport START:END semantics.
+#   - consumed today: scripts/wsl2-netns-setup.sh (cycle v0.4.1 / Unit 001)
+#   - to be consumed by: lib/sandbox.sh and lib/netns_const_loader.py
+#     (cycle v0.4.1 / Unit 002 — proxy bind enforcement + Python consumer)
+# Value validation (integer / 1..65535 / START <= END) is the consumer's
+# responsibility; this file stays side-effect free (assignments only).
+JAILRUN_PROXY_PORT_RANGE_START="60000"
+JAILRUN_PROXY_PORT_RANGE_END="60099"

--- a/lib/netns_const_loader.py
+++ b/lib/netns_const_loader.py
@@ -1,0 +1,128 @@
+"""Python loader for the proxy port range SoT defined in lib/netns-const.sh.
+
+Single public API: ``load_port_range()`` returns ``(start, end)`` integers
+that satisfy ``1 <= start <= end <= 65535`` (closed interval, matching the
+iptables ``--dport START:END`` semantics applied by
+``scripts/wsl2-netns-setup.sh``). All other helpers are private.
+
+Resolution: ``__file__``-relative ``netns-const.sh`` in the same ``lib/``
+directory. The loader does **not** consult any environment variable to
+locate the SoT (cycle v0.4.1 / Unit 002 domain-model invariant I4 — no
+runtime SoT override path). When installed via ``make install``, the file
+ends up next to ``proxy.py`` automatically. Tests that need to inject a
+fixture monkeypatch :func:`_resolve_netns_const_path` directly instead of
+setting an environment variable.
+
+Failure modes (all raise :class:`RuntimeError` with the resolved absolute
+path included in the message):
+
+- shell file not found
+- ``sh`` subprocess exits non-zero / produces fewer than 2 stdout lines
+  / produces non-numeric or leading-zero values
+- ``START`` or ``END`` outside ``1..65535`` / ``START > END``
+
+This Python validation mirrors the consumer-side validation in
+``scripts/wsl2-netns-setup.sh`` so the contract documented in cycle
+v0.4.1 / Unit 001 stays single-sourced. Shared test vectors live in
+``tests/port_range_invalid_vectors.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = ["load_port_range"]
+
+
+_PORT_MIN = 1
+_PORT_MAX = 65535
+
+# Inline shell script used to extract the two SoT values. Receives the
+# netns-const.sh absolute path as $1 (positional, NOT string-interpolated)
+# so any future change to the path representation cannot inject shell
+# syntax (cycle v0.4.1 / Unit 002 code review R1 #1).
+_EXTRACT_SCRIPT = (
+    '. "$1" && '
+    'printf "%s\\n%s" '
+    '"$JAILRUN_PROXY_PORT_RANGE_START" '
+    '"$JAILRUN_PROXY_PORT_RANGE_END"'
+)
+
+
+def _resolve_netns_const_path() -> Path:
+    return Path(__file__).resolve().parent / "netns-const.sh"
+
+
+def _read_raw_values(sot_path: Path) -> tuple[str, str]:
+    if not sot_path.is_file():
+        raise RuntimeError(f"netns-const.sh not found at {sot_path}")
+
+    proc = subprocess.run(
+        ["sh", "-c", _EXTRACT_SCRIPT, "netns_const_loader", str(sot_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "invalid JAILRUN_PROXY_PORT_RANGE: sh exited "
+            f"{proc.returncode} ({proc.stderr.strip()}); "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    lines = proc.stdout.split("\n")
+    if len(lines) < 2:
+        raise RuntimeError(
+            "invalid JAILRUN_PROXY_PORT_RANGE: subprocess returned "
+            f"fewer than 2 lines (got {len(lines)}); "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    return lines[0], lines[1]
+
+
+def _validate_int_str(raw: str, label: str, sot_path: Path) -> int:
+    if raw == "":
+        raise RuntimeError(
+            f"invalid JAILRUN_PROXY_PORT_RANGE: {label} is empty; "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    if not raw.isdigit():
+        raise RuntimeError(
+            f"invalid JAILRUN_PROXY_PORT_RANGE: {label}={raw!r} is "
+            f"not a decimal integer; resolved netns-const.sh path: {sot_path}"
+        )
+    # Leading-zero rejection mirrors setup.sh's case '0|0[0-9]*'.
+    if len(raw) > 1 and raw[0] == "0":
+        raise RuntimeError(
+            f"invalid JAILRUN_PROXY_PORT_RANGE: {label}={raw!r} has a "
+            f"leading zero; resolved netns-const.sh path: {sot_path}"
+        )
+    if raw == "0":
+        raise RuntimeError(
+            f"invalid JAILRUN_PROXY_PORT_RANGE: {label}=0 is below the "
+            f"valid range [{_PORT_MIN}, {_PORT_MAX}]; "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    value = int(raw)
+    if value < _PORT_MIN or value > _PORT_MAX:
+        raise RuntimeError(
+            f"invalid JAILRUN_PROXY_PORT_RANGE: {label}={value} is "
+            f"outside [{_PORT_MIN}, {_PORT_MAX}]; "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    return value
+
+
+def load_port_range() -> tuple[int, int]:
+    """Return the proxy port range ``(START, END)`` from the shell SoT."""
+    sot_path = _resolve_netns_const_path()
+    raw_start, raw_end = _read_raw_values(sot_path)
+    start = _validate_int_str(raw_start, "START", sot_path)
+    end = _validate_int_str(raw_end, "END", sot_path)
+    if start > end:
+        raise RuntimeError(
+            "invalid JAILRUN_PROXY_PORT_RANGE: "
+            f"START={start} > END={end}; "
+            f"resolved netns-const.sh path: {sot_path}"
+        )
+    return start, end

--- a/lib/proxy.py
+++ b/lib/proxy.py
@@ -21,6 +21,8 @@ import socket
 import sys
 import threading
 
+from netns_const_loader import load_port_range
+
 logger = logging.getLogger("jailrun-proxy")
 
 # RFC1918 + link-local + loopback + metadata endpoints
@@ -185,11 +187,47 @@ def handle_client(
             pass
 
 
+def _bind_in_range(bind: str, start: int, end: int) -> socket.socket:
+    """Try sequential bind across [start, end] and return the first success.
+
+    Mirrors the iptables --dport START:END contract from cycle v0.4.1 /
+    Unit 001: the proxy must never bind outside the SoT range, so the
+    ephemeral path does NOT fall back to OS-assigned ports.
+    """
+    last_error: OSError | None = None
+    for candidate in range(start, end + 1):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((bind, candidate))
+            return sock
+        except OSError as exc:
+            last_error = exc
+            sock.close()
+            continue
+    tried = end - start + 1
+    raise RuntimeError(
+        f"failed to bind to any port in range [{start}, {end}] "
+        f"(tried {tried}, last error: {last_error})"
+    )
+
+
 def run_proxy(allowed_domains: set[str], port: int = 0, bind: str = "127.0.0.1") -> None:
-    """Start the proxy server."""
-    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.bind((bind, port))
+    """Start the proxy server, constrained to the configured port range."""
+    start, end = load_port_range()
+
+    if port == 0:
+        server = _bind_in_range(bind, start, end)
+    else:
+        if port < start or port > end:
+            raise RuntimeError(
+                f"requested port {port} is outside the configured proxy "
+                f"port range [{start}, {end}]"
+            )
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((bind, port))
+
     server.listen(128)
 
     actual_port = server.getsockname()[1]
@@ -250,7 +288,11 @@ def main() -> None:
         logger.error("no allowed domains specified")
         sys.exit(1)
 
-    run_proxy(allowed, args.port, args.bind)
+    try:
+        run_proxy(allowed, args.port, args.bind)
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/lib/proxy.py
+++ b/lib/proxy.py
@@ -10,15 +10,24 @@ Usage:
 
 The proxy prints the listening port to stdout on startup, then logs to stderr.
 
-Since cycle v0.4.1, the bind port is always inside the SoT range defined in
-``lib/netns-const.sh`` (``JAILRUN_PROXY_PORT_RANGE_START..END``):
+Cycle v0.4.1 introduces an optional ``--enforce-port-range`` flag that
+locks the bind to the SoT range in ``lib/netns-const.sh``
+(``JAILRUN_PROXY_PORT_RANGE_START..END``). The flag is **off** by default
+so plain ``127.0.0.1`` callers (no WSL2 netns) keep the full OS ephemeral
+range and concurrent local jailrun runs do not contend for a 100-port
+window. ``lib/sandbox.sh`` passes ``--enforce-port-range`` only when the
+``agentns`` namespace is active (i.e. when the netns OUTPUT iptables
+``--dport`` rule actually constrains traffic).
+
+When ``--enforce-port-range`` is set:
 
 - ``--port N`` with N outside [START, END] is rejected (fail-closed)
-- ``--port 0`` (default) does NOT fall back to OS ephemeral ports; the proxy
-  scans [START, END] sequentially and binds the first available port
+- ``--port 0`` (default) does NOT fall back to OS ephemeral ports; the
+  proxy scans [START, END] sequentially and binds the first available
+  port
 
-This keeps the proxy's bind range in lock-step with the WSL2 netns iptables
-``--dport`` rule installed by ``scripts/wsl2-netns-setup.sh``.
+When the flag is **not** set, the proxy uses the unrestricted bind
+behaviour from v0.4.0.
 """
 
 from __future__ import annotations
@@ -222,18 +231,35 @@ def _bind_in_range(bind: str, start: int, end: int) -> socket.socket:
     )
 
 
-def run_proxy(allowed_domains: set[str], port: int = 0, bind: str = "127.0.0.1") -> None:
-    """Start the proxy server, constrained to the configured port range."""
-    start, end = load_port_range()
+def run_proxy(
+    allowed_domains: set[str],
+    port: int = 0,
+    bind: str = "127.0.0.1",
+    enforce_port_range: bool = False,
+) -> None:
+    """Start the proxy server.
 
-    if port == 0:
-        server = _bind_in_range(bind, start, end)
+    When ``enforce_port_range`` is True, the bind is constrained to the SoT
+    range from ``lib/netns-const.sh`` (matching the WSL2 netns iptables
+    ``--dport`` rule). When False (default), the bind uses the unrestricted
+    v0.4.0 behaviour — ``port`` is passed straight to ``bind()`` so
+    ``--port 0`` resolves via the OS ephemeral pool.
+    """
+    if enforce_port_range:
+        start, end = load_port_range()
+
+        if port == 0:
+            server = _bind_in_range(bind, start, end)
+        else:
+            if port < start or port > end:
+                raise RuntimeError(
+                    f"requested port {port} is outside the configured proxy "
+                    f"port range [{start}, {end}]"
+                )
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind((bind, port))
     else:
-        if port < start or port > end:
-            raise RuntimeError(
-                f"requested port {port} is outside the configured proxy "
-                f"port range [{start}, {end}]"
-            )
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         server.bind((bind, port))
@@ -285,6 +311,15 @@ def main() -> None:
         default="127.0.0.1",
         help="Address to bind to (default: 127.0.0.1)",
     )
+    parser.add_argument(
+        "--enforce-port-range",
+        action="store_true",
+        help=(
+            "Restrict bind to JAILRUN_PROXY_PORT_RANGE_START..END from "
+            "lib/netns-const.sh (default: off; used by sandbox.sh when "
+            "agentns is active to match the iptables --dport rule)"
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -299,7 +334,7 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        run_proxy(allowed, args.port, args.bind)
+        run_proxy(allowed, args.port, args.bind, args.enforce_port_range)
     except RuntimeError as exc:
         logger.error("%s", exc)
         sys.exit(1)

--- a/lib/proxy.py
+++ b/lib/proxy.py
@@ -9,6 +9,16 @@ Usage:
     python3 proxy.py --allow-domains "api.anthropic.com,github.com" [--port 0]
 
 The proxy prints the listening port to stdout on startup, then logs to stderr.
+
+Since cycle v0.4.1, the bind port is always inside the SoT range defined in
+``lib/netns-const.sh`` (``JAILRUN_PROXY_PORT_RANGE_START..END``):
+
+- ``--port N`` with N outside [START, END] is rejected (fail-closed)
+- ``--port 0`` (default) does NOT fall back to OS ephemeral ports; the proxy
+  scans [START, END] sequentially and binds the first available port
+
+This keeps the proxy's bind range in lock-step with the WSL2 netns iptables
+``--dport`` rule installed by ``scripts/wsl2-netns-setup.sh``.
 """
 
 from __future__ import annotations

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -401,14 +401,18 @@ _start_proxy() {
   # Convert space-separated to comma-separated for proxy.py
   _domains=$(printf '%s' "$PROXY_ALLOW_DOMAINS" | tr ' ' ',')
 
-  # Bind to veth-host IP when network namespace is active. proxy.py picks
-  # an actual port from the SoT range JAILRUN_PROXY_PORT_RANGE_START..END
-  # (lib/netns-const.sh, see cycle v0.4.1 / Unit 002) — we do not pass
-  # --port and intentionally rely on proxy.py's own ranged ephemeral
-  # allocation so the bind always matches the netns OUTPUT --dport rule.
+  # Bind to veth-host IP when network namespace is active. In netns mode we
+  # also pass --enforce-port-range so proxy.py constrains its bind to the
+  # SoT range JAILRUN_PROXY_PORT_RANGE_START..END (lib/netns-const.sh, see
+  # cycle v0.4.1 / Unit 002) — this is what keeps proxy bind and the netns
+  # OUTPUT --dport rule in lock-step. Outside netns we deliberately leave
+  # the flag off so plain 127.0.0.1 launches keep using the full OS
+  # ephemeral pool (v0.4.0 behaviour, see PR #89 pre-merge review).
   _proxy_bind="127.0.0.1"
+  _proxy_extra_args=""
   if [ -n "$_NETNS" ]; then
     _proxy_bind="$JAILRUN_NETNS_HOST_IP"
+    _proxy_extra_args="--enforce-port-range"
   fi
 
   # Start proxy, capture port from first stdout line via FIFO.
@@ -418,7 +422,7 @@ _start_proxy() {
   _fifo="$_tmpdir/proxy-port"
   mkfifo "$_fifo"
   _proxy_log="$_tmpdir/proxy.log"
-  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" --bind "$_proxy_bind" > "$_fifo" 2>"$_proxy_log" &
+  python3 "$JAILRUN_LIB/proxy.py" --allow-domains "$_domains" --bind "$_proxy_bind" $_proxy_extra_args > "$_fifo" 2>"$_proxy_log" &
   _proxy_pid=$!
   echo "[$_WRAPPER_NAME] proxy log: $_proxy_log" >&2
   read -r _proxy_port < "$_fifo"

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -401,7 +401,11 @@ _start_proxy() {
   # Convert space-separated to comma-separated for proxy.py
   _domains=$(printf '%s' "$PROXY_ALLOW_DOMAINS" | tr ' ' ',')
 
-  # Bind to veth-host IP when network namespace is active
+  # Bind to veth-host IP when network namespace is active. proxy.py picks
+  # an actual port from the SoT range JAILRUN_PROXY_PORT_RANGE_START..END
+  # (lib/netns-const.sh, see cycle v0.4.1 / Unit 002) — we do not pass
+  # --port and intentionally rely on proxy.py's own ranged ephemeral
+  # allocation so the bind always matches the netns OUTPUT --dport rule.
   _proxy_bind="127.0.0.1"
   if [ -n "$_NETNS" ]; then
     _proxy_bind="$JAILRUN_NETNS_HOST_IP"

--- a/scripts/wsl2-netns-setup.sh
+++ b/scripts/wsl2-netns-setup.sh
@@ -3,8 +3,9 @@
 # Usage: sudo scripts/wsl2-netns-setup.sh
 # Idempotent — safe to run multiple times.
 #
-# Creates a network namespace "agentns" with a veth pair so that
-# processes inside can only reach the proxy at 10.200.0.1.
+# Creates a network namespace "agentns" with a veth pair so that processes
+# inside can only reach the proxy at 10.200.0.1 on the configured TCP port
+# range (JAILRUN_PROXY_PORT_RANGE_START:JAILRUN_PROXY_PORT_RANGE_END).
 
 set -euo pipefail
 
@@ -27,10 +28,36 @@ if [ -z "${JAILRUN_NETNS_NAME:-}" ] || [ -z "${JAILRUN_NETNS_VETH_HOST:-}" ] \
   exit 1
 fi
 
+if [ -z "${JAILRUN_PROXY_PORT_RANGE_START:-}" ] || [ -z "${JAILRUN_PROXY_PORT_RANGE_END:-}" ]; then
+  echo "error: netns constants incomplete in $NETNS_CONST" >&2
+  exit 1
+fi
+
+# Validate that the SoT port range satisfies the contract documented in
+# lib/netns-const.sh: decimal integer without leading zeros / 1..65535 /
+# START <= END. lib/netns-const.sh is intentionally assignment-only, so
+# verification lives on the consumer.
+_range_invalid=0
+for _range_value in "$JAILRUN_PROXY_PORT_RANGE_START" "$JAILRUN_PROXY_PORT_RANGE_END"; do
+  case "$_range_value" in
+    ''|*[!0-9]*|0|0[0-9]*) _range_invalid=1 ;;
+  esac
+done
+if [ "$_range_invalid" -eq 1 ] \
+  || [ "$JAILRUN_PROXY_PORT_RANGE_START" -lt 1 ] \
+  || [ "$JAILRUN_PROXY_PORT_RANGE_END" -gt 65535 ] \
+  || [ "$JAILRUN_PROXY_PORT_RANGE_START" -gt "$JAILRUN_PROXY_PORT_RANGE_END" ]; then
+  echo "error: JAILRUN_PROXY_PORT_RANGE_START / _END must be integers in 1..65535 with START <= END (got START=$JAILRUN_PROXY_PORT_RANGE_START, END=$JAILRUN_PROXY_PORT_RANGE_END)" >&2
+  exit 1
+fi
+unset _range_invalid _range_value
+
 NS="$JAILRUN_NETNS_NAME"
 VETH_HOST="$JAILRUN_NETNS_VETH_HOST"
 VETH_AGENT="$JAILRUN_NETNS_VETH_AGENT"
 HOST_IP="$JAILRUN_NETNS_HOST_IP"
+PORT_RANGE_START="$JAILRUN_PROXY_PORT_RANGE_START"
+PORT_RANGE_END="$JAILRUN_PROXY_PORT_RANGE_END"
 AGENT_IP="10.200.0.2"
 CIDR="24"
 
@@ -64,11 +91,14 @@ ip netns exec "$NS" ip link set "$VETH_AGENT" up
 ip netns exec "$NS" ip route replace default via "$HOST_IP"
 
 # --- iptables (inside namespace) ---
-# OUTPUT: default DROP, allow loopback and traffic to the proxy host IP.
+# OUTPUT: default DROP, allow loopback and TCP to the proxy host IP on the
+# configured port range only (defense-in-depth — see lib/netns-const.sh and
+# .aidlc/cycles/v0.4.1/requirements/intent.md M1/M2 for the SoT contract).
 ip netns exec "$NS" iptables -P OUTPUT DROP
 ip netns exec "$NS" iptables -F OUTPUT
 ip netns exec "$NS" iptables -A OUTPUT -o lo -j ACCEPT
-ip netns exec "$NS" iptables -A OUTPUT -p tcp -d "$HOST_IP" -j ACCEPT
+ip netns exec "$NS" iptables -A OUTPUT -p tcp -d "$HOST_IP" \
+  --dport "$PORT_RANGE_START":"$PORT_RANGE_END" -j ACCEPT
 # INPUT: default DROP, allow loopback and replies to agent-initiated flows.
 # Blocks unrelated host->agent direct connections (e.g. from 10.200.0.1).
 ip netns exec "$NS" iptables -P INPUT DROP
@@ -76,4 +106,4 @@ ip netns exec "$NS" iptables -F INPUT
 ip netns exec "$NS" iptables -A INPUT -i lo -j ACCEPT
 ip netns exec "$NS" iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
-echo "[done] namespace '$NS' ready — proxy binds to $HOST_IP (any port)"
+echo "[done] namespace '$NS' ready — proxy binds to $HOST_IP ports $PORT_RANGE_START:$PORT_RANGE_END"

--- a/tests/port_range_invalid_vectors.py
+++ b/tests/port_range_invalid_vectors.py
@@ -1,0 +1,24 @@
+"""Shared invalid-value test vectors for the proxy port range SoT.
+
+Single source of truth for the value-validation contract that both the
+Python loader (``lib/netns_const_loader.py``) and the shell consumer
+(``scripts/wsl2-netns-setup.sh``) must agree on. Both test suites import
+or read from this file directly — there is no mirrored TSV / YAML, so a
+divergence is impossible.
+
+Each tuple is ``(start_raw, end_raw, reason_label)``.
+"""
+
+from __future__ import annotations
+
+INVALID_VECTORS: list[tuple[str, str, str]] = [
+    ("0001", "60099", "leading-zero-start"),
+    ("60000", "0099", "leading-zero-end"),
+    ("abc", "60099", "non-integer-start"),
+    ("60000", "abc", "non-integer-end"),
+    ("0", "60099", "below-min-start"),
+    ("60000", "65536", "above-max-end"),
+    ("60100", "60050", "reversed-range"),
+    ("", "60099", "empty-start"),
+    ("60000", "", "empty-end"),
+]

--- a/tests/proxy_parallel_availability.bats
+++ b/tests/proxy_parallel_availability.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Cycle v0.4.1 / Unit 002 / Issue #86 (M6 / T6)
+# Parallel availability of lib/proxy.py inside the configured SoT range.
+#
+# Spawns N proxies in parallel for ITERATIONS rounds (Intent M6: N=10,
+# 5 iterations = 50 attempts). Verifies that every bind lands inside
+# [START, END] and that no two parallel processes pick the same port
+# in a single iteration.
+#
+# Per cycle v0.4.1 Unit 002 logical design "収集規約":
+#   PIDS / STDOUT_FILES / STDERR_FILES / PORTS share the same index i,
+#   one process == one stdout file == one stderr file. Always
+#   spawn -> readiness -> kill -> wait -> verify, with teardown() doing
+#   defensive PID cleanup so leaks do not poison the next iteration.
+
+load helpers
+
+setup() {
+  _repo_root="$BATS_TEST_DIRNAME/.."
+  _proxy="$_repo_root/lib/proxy.py"
+  _const="$_repo_root/lib/netns-const.sh"
+
+  # shellcheck disable=SC1090
+  . "$_const"
+  _range_start="$JAILRUN_PROXY_PORT_RANGE_START"
+  _range_end="$JAILRUN_PROXY_PORT_RANGE_END"
+
+  PIDS=()
+  STDOUT_FILES=()
+  STDERR_FILES=()
+}
+
+teardown() {
+  local pid
+  for pid in "${PIDS[@]}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+@test "proxy bind stays in range under N=10 parallel x 5 iterations" {
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required"
+  fi
+
+  local N=10
+  local ITERATIONS=5
+  local i j
+
+  for i in $(seq 1 "$ITERATIONS"); do
+    PIDS=()
+    STDOUT_FILES=()
+    STDERR_FILES=()
+
+    # spawn
+    for j in $(seq 0 $((N - 1))); do
+      local out="$BATS_TEST_TMPDIR/proxy.$i.$j.out"
+      local err="$BATS_TEST_TMPDIR/proxy.$i.$j.err"
+      STDOUT_FILES[j]="$out"
+      STDERR_FILES[j]="$err"
+      python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 \
+        >"$out" 2>"$err" &
+      PIDS[j]=$!
+    done
+
+    # readiness + assert range
+    local PORTS=()
+    for j in $(seq 0 $((N - 1))); do
+      local outfile="${STDOUT_FILES[$j]}"
+      local errfile="${STDERR_FILES[$j]}"
+      local k
+      local ready=0
+      for k in $(seq 1 30); do
+        if [ -s "$outfile" ]; then
+          ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$ready" -ne 1 ]; then
+        echo "iteration=$i slot=$j: proxy never produced a port within 3s" >&2
+        cat "$errfile" >&2 || true
+        false
+      fi
+      local port
+      port=$(head -n 1 "$outfile")
+      [ "$port" -ge "$_range_start" ]
+      [ "$port" -le "$_range_end" ]
+      PORTS[j]="$port"
+    done
+
+    # uniqueness within the iteration: 10 distinct ports.
+    local unique_count
+    unique_count=$(printf '%s\n' "${PORTS[@]}" | sort -u | wc -l | tr -d ' ')
+    [ "$unique_count" -eq "$N" ]
+
+    # kill + wait
+    for j in $(seq 0 $((N - 1))); do
+      kill "${PIDS[$j]}" 2>/dev/null || true
+    done
+    for j in $(seq 0 $((N - 1))); do
+      wait "${PIDS[$j]}" 2>/dev/null || true
+    done
+    PIDS=()
+    STDOUT_FILES=()
+    STDERR_FILES=()
+  done
+}

--- a/tests/proxy_parallel_availability.bats
+++ b/tests/proxy_parallel_availability.bats
@@ -61,7 +61,10 @@ teardown() {
       local err="$BATS_TEST_TMPDIR/proxy.$i.$j.err"
       STDOUT_FILES[j]="$out"
       STDERR_FILES[j]="$err"
-      python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 \
+      # --enforce-port-range matches the production netns invocation
+      # (sandbox.sh passes this flag when _NETNS is set); we exercise
+      # the same code path here to validate range capacity at N=10.
+      python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 --enforce-port-range \
         >"$out" 2>"$err" &
       PIDS[j]=$!
     done

--- a/tests/proxy_port_range.bats
+++ b/tests/proxy_port_range.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+# Cycle v0.4.1 / Unit 002 / Issue #86
+# CLI-level checks that lib/proxy.py honours the SoT port range:
+#   - explicit --port outside [START, END] fails closed (range-out below + above)
+#   - default --port 0 binds inside [START, END]
+#
+# These are behavioural assertions per the Phase 1 logical design
+# ("主検証は挙動ベース" — codex design R2 #3). Import-statement greps were
+# explicitly removed because they are too tightly coupled to implementation
+# details and break on equivalent refactors.
+
+load helpers
+
+setup() {
+  _repo_root="$BATS_TEST_DIRNAME/.."
+  _proxy="$_repo_root/lib/proxy.py"
+  _const="$_repo_root/lib/netns-const.sh"
+
+  # shellcheck disable=SC1090
+  . "$_const"
+  _range_start="$JAILRUN_PROXY_PORT_RANGE_START"
+  _range_end="$JAILRUN_PROXY_PORT_RANGE_END"
+
+  _proxy_pid=""
+}
+
+teardown() {
+  if [ -n "$_proxy_pid" ] && kill -0 "$_proxy_pid" 2>/dev/null; then
+    kill "$_proxy_pid" 2>/dev/null || true
+    wait "$_proxy_pid" 2>/dev/null || true
+  fi
+}
+
+# --- explicit out-of-range port: below the start ---
+
+@test "proxy.py fails closed when --port is below the SoT range" {
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required"
+  fi
+  local below=$((_range_start - 1))
+  if [ "$below" -lt 1 ]; then
+    skip "SoT range starts at 1; no below-range value to test"
+  fi
+  run python3 "$_proxy" --allow-domains test.invalid --port "$below"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"outside the configured proxy port range"* ]]
+}
+
+# --- explicit out-of-range port: above the end ---
+
+@test "proxy.py fails closed when --port is above the SoT range" {
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required"
+  fi
+  local above=$((_range_end + 1))
+  if [ "$above" -gt 65535 ]; then
+    skip "SoT range ends at 65535; no above-range value to test"
+  fi
+  run python3 "$_proxy" --allow-domains test.invalid --port "$above"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"outside the configured proxy port range"* ]]
+}
+
+# --- default --port 0: must land inside [START, END] ---
+
+@test "proxy.py default --port=0 binds inside the SoT range" {
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required"
+  fi
+  local outfile="$BATS_TEST_TMPDIR/proxy.out"
+  local errfile="$BATS_TEST_TMPDIR/proxy.err"
+  python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 \
+    >"$outfile" 2>"$errfile" &
+  _proxy_pid=$!
+
+  # Wait up to 3s for the first stdout line (= bind port).
+  local i
+  for i in $(seq 1 30); do
+    if [ -s "$outfile" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  [ -s "$outfile" ] || { cat "$errfile" >&2; false; }
+
+  local port
+  port=$(head -n 1 "$outfile")
+  [ "$port" -ge "$_range_start" ]
+  [ "$port" -le "$_range_end" ]
+}

--- a/tests/proxy_port_range.bats
+++ b/tests/proxy_port_range.bats
@@ -34,7 +34,7 @@ teardown() {
 
 # --- explicit out-of-range port: below the start ---
 
-@test "proxy.py fails closed when --port is below the SoT range" {
+@test "proxy.py fails closed when --port is below the SoT range with --enforce-port-range" {
   if ! command -v python3 >/dev/null 2>&1; then
     skip "python3 required"
   fi
@@ -42,14 +42,14 @@ teardown() {
   if [ "$below" -lt 1 ]; then
     skip "SoT range starts at 1; no below-range value to test"
   fi
-  run python3 "$_proxy" --allow-domains test.invalid --port "$below"
+  run python3 "$_proxy" --allow-domains test.invalid --enforce-port-range --port "$below"
   [ "$status" -ne 0 ]
   [[ "$output" == *"outside the configured proxy port range"* ]]
 }
 
 # --- explicit out-of-range port: above the end ---
 
-@test "proxy.py fails closed when --port is above the SoT range" {
+@test "proxy.py fails closed when --port is above the SoT range with --enforce-port-range" {
   if ! command -v python3 >/dev/null 2>&1; then
     skip "python3 required"
   fi
@@ -57,20 +57,20 @@ teardown() {
   if [ "$above" -gt 65535 ]; then
     skip "SoT range ends at 65535; no above-range value to test"
   fi
-  run python3 "$_proxy" --allow-domains test.invalid --port "$above"
+  run python3 "$_proxy" --allow-domains test.invalid --enforce-port-range --port "$above"
   [ "$status" -ne 0 ]
   [[ "$output" == *"outside the configured proxy port range"* ]]
 }
 
-# --- default --port 0: must land inside [START, END] ---
+# --- default --port 0 with --enforce-port-range: must land inside [START, END] ---
 
-@test "proxy.py default --port=0 binds inside the SoT range" {
+@test "proxy.py with --enforce-port-range binds inside the SoT range" {
   if ! command -v python3 >/dev/null 2>&1; then
     skip "python3 required"
   fi
   local outfile="$BATS_TEST_TMPDIR/proxy.out"
   local errfile="$BATS_TEST_TMPDIR/proxy.err"
-  python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 \
+  python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 --enforce-port-range \
     >"$outfile" 2>"$errfile" &
   _proxy_pid=$!
 
@@ -88,4 +88,35 @@ teardown() {
   port=$(head -n 1 "$outfile")
   [ "$port" -ge "$_range_start" ]
   [ "$port" -le "$_range_end" ]
+}
+
+# --- default --port 0 WITHOUT --enforce-port-range: uses unrestricted OS
+# ephemeral pool (regression guard for v0.4.0 behaviour, per PR #89
+# pre-merge review) ---
+
+@test "proxy.py without --enforce-port-range uses OS ephemeral pool" {
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required"
+  fi
+  local outfile="$BATS_TEST_TMPDIR/proxy_unrestricted.out"
+  local errfile="$BATS_TEST_TMPDIR/proxy_unrestricted.err"
+  python3 "$_proxy" --allow-domains test.invalid --bind 127.0.0.1 \
+    >"$outfile" 2>"$errfile" &
+  _proxy_pid=$!
+
+  local i
+  for i in $(seq 1 30); do
+    if [ -s "$outfile" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  [ -s "$outfile" ] || { cat "$errfile" >&2; false; }
+
+  local port
+  port=$(head -n 1 "$outfile")
+  # Any port > 0 is fine; the assertion is "the proxy started without
+  # being squeezed into 60000..60099" — we accept the OS-chosen port.
+  [ "$port" -gt 0 ]
+  [ "$port" -le 65535 ]
 }

--- a/tests/test_netns_const_loader.py
+++ b/tests/test_netns_const_loader.py
@@ -1,0 +1,117 @@
+"""Unit tests for lib/netns_const_loader.load_port_range.
+
+The loader resolves netns-const.sh strictly via ``__file__`` (cycle
+v0.4.1 / Unit 002 code review R1 #2 — no environment-variable override
+path), so the fixture tests monkeypatch the private
+``_resolve_netns_const_path`` instead of touching the environment.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+import netns_const_loader  # noqa: E402
+from netns_const_loader import load_port_range  # noqa: E402
+from port_range_invalid_vectors import INVALID_VECTORS  # noqa: E402
+
+
+def _write_fixture(dirpath: Path, start: str, end: str) -> Path:
+    sot = dirpath / "netns-const.sh"
+    sot.write_text(
+        textwrap.dedent(
+            f"""\
+            JAILRUN_NETNS_HOST_IP="10.200.0.1"
+            JAILRUN_NETNS_NAME="agentns"
+            JAILRUN_NETNS_VETH_HOST="veth-host"
+            JAILRUN_NETNS_VETH_AGENT="veth-agent"
+            JAILRUN_PROXY_PORT_RANGE_START="{start}"
+            JAILRUN_PROXY_PORT_RANGE_END="{end}"
+            """
+        )
+    )
+    return sot
+
+
+class LoadPortRangeTest(unittest.TestCase):
+    # ---- happy path ----
+
+    def test_resolves_via_file_relative_default(self) -> None:
+        # __file__ relative resolves to lib/netns-const.sh in the repo,
+        # which currently ships 60000/60099 as the SoT default.
+        self.assertEqual(load_port_range(), (60000, 60099))
+
+    def test_returns_fixture_values_when_path_patched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sot = _write_fixture(Path(tmp), "60001", "60100")
+            with patch.object(
+                netns_const_loader, "_resolve_netns_const_path",
+                return_value=sot,
+            ):
+                self.assertEqual(load_port_range(), (60001, 60100))
+
+    # ---- missing file ----
+
+    def test_missing_file_raises_with_resolved_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "netns-const.sh"
+            with patch.object(
+                netns_const_loader, "_resolve_netns_const_path",
+                return_value=missing,
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    load_port_range()
+            msg = str(ctx.exception)
+            self.assertIn("netns-const.sh not found", msg)
+            self.assertIn(str(missing), msg)
+
+    # ---- shared invalid vectors ----
+
+    def test_invalid_vectors_raise_runtime_error(self) -> None:
+        for raw_start, raw_end, label in INVALID_VECTORS:
+            with self.subTest(label=label, start=raw_start, end=raw_end):
+                with tempfile.TemporaryDirectory() as tmp:
+                    sot = _write_fixture(Path(tmp), raw_start, raw_end)
+                    with patch.object(
+                        netns_const_loader, "_resolve_netns_const_path",
+                        return_value=sot,
+                    ):
+                        with self.assertRaises(RuntimeError) as ctx:
+                            load_port_range()
+                    msg = str(ctx.exception)
+                    # All errors must include the resolved SoT absolute
+                    # path (contract I5 in the domain model).
+                    self.assertIn(str(sot), msg)
+
+    # ---- error message contract ----
+
+    def test_error_message_includes_resolved_path_on_validation_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sot = _write_fixture(Path(tmp), "abc", "60099")
+            with patch.object(
+                netns_const_loader, "_resolve_netns_const_path",
+                return_value=sot,
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    load_port_range()
+            msg = str(ctx.exception)
+            self.assertIn("invalid JAILRUN_PROXY_PORT_RANGE", msg)
+            self.assertIn(str(sot), msg)
+
+    # ---- module surface ----
+
+    def test_module_exposes_only_load_port_range(self) -> None:
+        # Domain model R1 #1 / R2 #1: public API is the function only.
+        self.assertEqual(netns_const_loader.__all__, ["load_port_range"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -243,15 +243,41 @@ class TestRunProxyPortRange(unittest.TestCase):
     on real sockets lives in the bats suites.
     """
 
-    def test_explicit_port_below_range_raises(self):
+    def test_explicit_port_below_range_raises_when_enforced(self):
         with self.assertRaises(RuntimeError) as ctx:
-            proxy.run_proxy({"test.invalid"}, port=99, bind="127.0.0.1")
+            proxy.run_proxy(
+                {"test.invalid"}, port=99, bind="127.0.0.1",
+                enforce_port_range=True,
+            )
         self.assertIn("outside the configured proxy port range", str(ctx.exception))
 
-    def test_explicit_port_above_range_raises(self):
+    def test_explicit_port_above_range_raises_when_enforced(self):
         with self.assertRaises(RuntimeError) as ctx:
-            proxy.run_proxy({"test.invalid"}, port=65535, bind="127.0.0.1")
+            proxy.run_proxy(
+                {"test.invalid"}, port=65535, bind="127.0.0.1",
+                enforce_port_range=True,
+            )
         self.assertIn("outside the configured proxy port range", str(ctx.exception))
+
+    def test_below_range_port_is_allowed_without_enforce(self):
+        # Without --enforce-port-range, an "out of SoT" port like 0 or
+        # any free port is fine — this is the v0.4.0 behaviour that
+        # cycle v0.4.1 must preserve for non-netns callers.
+        import threading
+        thread = threading.Thread(
+            target=proxy.run_proxy,
+            args=({"test.invalid"},),
+            kwargs={"port": 0, "bind": "127.0.0.1"},
+            daemon=True,
+        )
+        # Start and immediately mark — the accept loop blocks forever,
+        # but bind/listen happen synchronously inside run_proxy before
+        # the loop. We only need to assert that bind did not raise.
+        thread.start()
+        thread.join(timeout=0.5)
+        # If bind had raised, the thread would have completed with an
+        # exception swallowed; here we just confirm it stayed alive.
+        self.assertTrue(thread.is_alive())
 
 
 if __name__ == "__main__":

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -184,5 +184,75 @@ class TestHandleClient(unittest.TestCase):
         mock_dns.assert_called_once_with("example.com", 443, socket.AF_UNSPEC, socket.SOCK_STREAM)
 
 
+class TestBindInRange(unittest.TestCase):
+    """Tests for proxy._bind_in_range (cycle v0.4.1 / Unit 002).
+
+    These exercise the helper directly; run_proxy integration is covered
+    by the bats suites (proxy_port_range.bats and
+    proxy_parallel_availability.bats).
+    """
+
+    def test_returns_socket_inside_range(self):
+        sock = proxy._bind_in_range("127.0.0.1", 60000, 60099)
+        try:
+            actual = sock.getsockname()[1]
+            self.assertGreaterEqual(actual, 60000)
+            self.assertLessEqual(actual, 60099)
+        finally:
+            sock.close()
+
+    def test_returns_first_available_port_in_order(self):
+        # Hold the very first port in a 2-port range so _bind_in_range
+        # is forced to skip to the next candidate.
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        holder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        holder.bind(("127.0.0.1", 0))
+        held_port = holder.getsockname()[1]
+        holder.listen(1)
+        try:
+            sock = proxy._bind_in_range(
+                "127.0.0.1", held_port, held_port + 1,
+            )
+            try:
+                self.assertEqual(sock.getsockname()[1], held_port + 1)
+            finally:
+                sock.close()
+        finally:
+            holder.close()
+
+    def test_exhausted_range_raises(self):
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        holder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        holder.bind(("127.0.0.1", 0))
+        held_port = holder.getsockname()[1]
+        holder.listen(1)
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                proxy._bind_in_range("127.0.0.1", held_port, held_port)
+            self.assertIn("failed to bind", str(ctx.exception))
+        finally:
+            holder.close()
+
+
+class TestRunProxyPortRange(unittest.TestCase):
+    """Tests for run_proxy's range enforcement (cycle v0.4.1 / Unit 002).
+
+    These cover the explicit ``--port N`` fail-closed path. The accept
+    loop is not exercised here — proxy.py's accept loop is covered by
+    the existing TestHandleClient suite, and bind-in-range integration
+    on real sockets lives in the bats suites.
+    """
+
+    def test_explicit_port_below_range_raises(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            proxy.run_proxy({"test.invalid"}, port=99, bind="127.0.0.1")
+        self.assertIn("outside the configured proxy port range", str(ctx.exception))
+
+    def test_explicit_port_above_range_raises(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            proxy.run_proxy({"test.invalid"}, port=65535, bind="127.0.0.1")
+        self.assertIn("outside the configured proxy port range", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/wsl2_netns.bats
+++ b/tests/wsl2_netns.bats
@@ -131,6 +131,17 @@ _netns_gate_or_skip() {
   rm -rf "$_prefix"
 }
 
+# Cycle v0.4.1 / Unit 002: lib/proxy.py now imports netns_const_loader at
+# launch, so the install payload must ship the loader alongside proxy.py
+# (regression guard for the PR pre-merge review finding in v0.4.1 #89).
+@test "make install distributes lib/netns_const_loader.py" {
+  _prefix="$(mktemp -d)"
+  run make -C "$_repo_root" install PREFIX="$_prefix"
+  [ "$status" -eq 0 ]
+  [ -f "$_prefix/lib/jailrun/netns_const_loader.py" ]
+  rm -rf "$_prefix"
+}
+
 # --- teardown script: non-root error path (runs everywhere) ---
 
 @test "wsl2-netns-teardown.sh is executable" {

--- a/tests/wsl2_netns_output_range.bats
+++ b/tests/wsl2_netns_output_range.bats
@@ -171,31 +171,43 @@ exec /usr/bin/env id "$@"
 EOSH
   chmod +x "$shim_bin/id"
 
-  cat >"$fixture_lib/netns-const.sh" <<'EOC'
+  # Iterate the shared test vectors (tests/port_range_invalid_vectors.py) —
+  # this is the same data the Python loader unit tests consume, so any
+  # divergence between setup.sh and lib/netns_const_loader.py is caught
+  # by both suites pointing at the same fixture set (cycle v0.4.1 / Unit 002
+  # logical design, codex plan R1 #4 + design R2 #2).
+  local vectors_script="$_repo_root/tests"
+  local vectors
+  vectors=$(python3 -c "
+import sys
+sys.path.insert(0, '$vectors_script')
+from port_range_invalid_vectors import INVALID_VECTORS
+for v in INVALID_VECTORS:
+    print('\t'.join(v))
+")
+  [ -n "$vectors" ]
+
+  local line
+  while IFS=$'\t' read -r raw_start raw_end label; do
+    cat >"$fixture_lib/netns-const.sh" <<EOC
 JAILRUN_NETNS_HOST_IP="10.200.0.1"
 JAILRUN_NETNS_NAME="agentns"
 JAILRUN_NETNS_VETH_HOST="veth-host"
 JAILRUN_NETNS_VETH_AGENT="veth-agent"
-JAILRUN_PROXY_PORT_RANGE_START="abc"
-JAILRUN_PROXY_PORT_RANGE_END="60099"
+JAILRUN_PROXY_PORT_RANGE_START="${raw_start}"
+JAILRUN_PROXY_PORT_RANGE_END="${raw_end}"
 EOC
-
-  PATH="$shim_bin:$PATH" run "$fixture/wsl2-netns-setup.sh"
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"JAILRUN_PROXY_PORT_RANGE_START / _END must be integers in 1..65535"* ]]
-
-  # Leading-zero rejection (decimal integer contract — no leading zeros).
-  cat >"$fixture_lib/netns-const.sh" <<'EOC'
-JAILRUN_NETNS_HOST_IP="10.200.0.1"
-JAILRUN_NETNS_NAME="agentns"
-JAILRUN_NETNS_VETH_HOST="veth-host"
-JAILRUN_NETNS_VETH_AGENT="veth-agent"
-JAILRUN_PROXY_PORT_RANGE_START="0001"
-JAILRUN_PROXY_PORT_RANGE_END="60099"
-EOC
-  PATH="$shim_bin:$PATH" run "$fixture/wsl2-netns-setup.sh"
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"must be integers in 1..65535"* ]]
+    PATH="$shim_bin:$PATH" run "$fixture/wsl2-netns-setup.sh"
+    if [ "$status" -eq 0 ]; then
+      echo "vector ${label} (${raw_start},${raw_end}) was accepted; expected exit 1" >&2
+      false
+    fi
+    if ! [[ "$output" == *"netns constants incomplete in"* \
+         || "$output" == *"must be integers in 1..65535"* ]]; then
+      echo "vector ${label} (${raw_start},${raw_end}) exit 1 but wrong message: $output" >&2
+      false
+    fi
+  done <<< "$vectors"
 }
 
 # --- B1: setup applies OUTPUT --dport range inside the namespace ---

--- a/tests/wsl2_netns_output_range.bats
+++ b/tests/wsl2_netns_output_range.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+
+# Cycle v0.4.1 / Unit 001 / Issue #86
+# Tests for the WSL2 network namespace OUTPUT iptables port-range scoping:
+#   - lib/netns-const.sh single SoT for JAILRUN_PROXY_PORT_RANGE_{START,END}
+#   - scripts/wsl2-netns-setup.sh applies --dport START:END on the OUTPUT
+#     ACCEPT rule, validates the SoT range on the consumer side and stays
+#     idempotent across re-setup runs.
+#
+# Static / structural tests run everywhere. Behavioural tests that need a
+# real network namespace (root + iptables + iproute2 + a listener on the
+# host side) are gated behind _netns_gate_or_skip and the iptables /
+# python3 availability checks — they are skipped on unprivileged CI and
+# only run with `sudo bats tests/wsl2_netns_output_range.bats` on a
+# Linux / WSL2 host (matching the existing tests/wsl2_netns.bats pattern).
+
+load helpers
+
+setup() {
+  _repo_root="$BATS_TEST_DIRNAME/.."
+  _setup="$_repo_root/scripts/wsl2-netns-setup.sh"
+  _teardown="$_repo_root/scripts/wsl2-netns-teardown.sh"
+  _const="$_repo_root/lib/netns-const.sh"
+
+  # shellcheck disable=SC1090
+  . "$_const"
+  _ns="$JAILRUN_NETNS_NAME"
+  _host_ip="$JAILRUN_NETNS_HOST_IP"
+  _range_start="$JAILRUN_PROXY_PORT_RANGE_START"
+  _range_end="$JAILRUN_PROXY_PORT_RANGE_END"
+
+  _listener_pid=""
+  _listener_log="$BATS_TEST_TMPDIR/listener.log"
+}
+
+teardown() {
+  if [ -n "$_listener_pid" ] && kill -0 "$_listener_pid" 2>/dev/null; then
+    kill "$_listener_pid" 2>/dev/null || true
+    wait "$_listener_pid" 2>/dev/null || true
+  fi
+}
+
+# Gate behavioural netns tests: need root + iproute2 + iptables. Skip
+# otherwise so the suite stays green on unprivileged CI.
+_netns_gate_or_skip() {
+  if [ "$(id -u)" -ne 0 ]; then
+    skip "root required for netns behaviour tests (run with sudo)"
+  fi
+  if ! command -v ip >/dev/null 2>&1; then
+    skip "ip (iproute2) required for netns behaviour tests"
+  fi
+  if ! command -v iptables >/dev/null 2>&1; then
+    skip "iptables required for netns behaviour tests"
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 required for the host-side listener helper"
+  fi
+}
+
+# Start a TCP listener on $_host_ip:<port> via python3 in the background.
+# Polls /dev/tcp until accept is ready (max 3 s). Fails the test (not
+# skip) when the listener does not come up — required to keep B2's
+# timeout signal attributable to the OUTPUT DROP rule (triangulation
+# in the logical design: B1 + B2 + B3 must run together).
+_start_host_listener() {
+  local port="$1"
+  python3 - "$_host_ip" "$port" >"$_listener_log" 2>&1 <<'PY' &
+import socket, sys, time
+host, port = sys.argv[1], int(sys.argv[2])
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind((host, port))
+s.listen(8)
+s.settimeout(30)
+try:
+    conn, _ = s.accept()
+    conn.close()
+except (socket.timeout, OSError):
+    pass
+finally:
+    s.close()
+PY
+  _listener_pid=$!
+
+  # Wait until the listener accepts a probing connect (max 3 s).
+  local i
+  for i in $(seq 1 30); do
+    if (exec 3<>"/dev/tcp/$_host_ip/$port") 2>/dev/null; then
+      exec 3<&-
+      exec 3>&-
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "listener did not become ready on $_host_ip:$port within 3s" >&2
+  cat "$_listener_log" >&2 || true
+  return 1
+}
+
+# --- S1: SoT defines port range variables ---
+
+@test "netns-const.sh defines port range variables" {
+  run sh -c '. "'"$_const"'" && printf "%s|%s" \
+    "$JAILRUN_PROXY_PORT_RANGE_START" "$JAILRUN_PROXY_PORT_RANGE_END"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "60000|60099" ]
+}
+
+# --- S2: netns-const.sh stays side-effect free with the new variables ---
+
+@test "netns-const.sh remains POSIX sh clean with port range additions" {
+  run sh -n "$_const"
+  [ "$status" -eq 0 ]
+  run sh -c '. "'"$_const"'"'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- S3: setup.sh OUTPUT rule has the --dport constraint ---
+
+@test "wsl2-netns-setup.sh OUTPUT rule has --dport range constraint" {
+  grep -qE '\-A OUTPUT -p tcp -d "\$HOST_IP" \\' "$_setup"
+  grep -qE -- '--dport "\$PORT_RANGE_START":"\$PORT_RANGE_END" -j ACCEPT' "$_setup"
+}
+
+# --- S4: setup.sh validates the SoT range on the consumer side ---
+
+@test "wsl2-netns-setup.sh validates the SoT port range" {
+  grep -qE 'JAILRUN_PROXY_PORT_RANGE_START / _END must be integers in 1\.\.65535' "$_setup"
+  # Range incompleteness path reuses the existing "constants incomplete" message.
+  grep -cE 'netns constants incomplete in \$NETNS_CONST' "$_setup" >/dev/null
+}
+
+# --- S5: setup.sh still passes bash -n after the changes ---
+
+@test "wsl2-netns-setup.sh passes bash -n with the new logic" {
+  run bash -n "$_setup"
+  [ "$status" -eq 0 ]
+}
+
+# --- S6: SoT values satisfy the invariants ---
+
+@test "port range satisfies invariants (1 <= START <= END <= 65535)" {
+  [ "$_range_start" -ge 1 ]
+  [ "$_range_end" -le 65535 ]
+  [ "$_range_start" -le "$_range_end" ]
+}
+
+# --- S7: setup.sh exits cleanly when the SoT port range is invalid ---
+
+@test "wsl2-netns-setup.sh rejects a non-integer port range" {
+  # Run via env override + a stub root check is impossible without sudo —
+  # so instead exercise the validation path via a controlled re-exec of
+  # the validation block. We copy the script and stub `id` to simulate
+  # root, then point NETNS_CONST at a fixture that injects bad values.
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "running as root would proceed past validation into real netns ops"
+  fi
+
+  local fixture="$BATS_TEST_TMPDIR/scripts"
+  local fixture_lib="$BATS_TEST_TMPDIR/lib"
+  mkdir -p "$fixture" "$fixture_lib"
+  cp "$_setup" "$fixture/wsl2-netns-setup.sh"
+  # Stub id => 0 by prepending a wrapper to PATH.
+  local shim_bin="$BATS_TEST_TMPDIR/shim-bin"
+  mkdir -p "$shim_bin"
+  cat >"$shim_bin/id" <<'EOSH'
+#!/bin/sh
+[ "$1" = "-u" ] && { printf 0; exit 0; }
+exec /usr/bin/env id "$@"
+EOSH
+  chmod +x "$shim_bin/id"
+
+  cat >"$fixture_lib/netns-const.sh" <<'EOC'
+JAILRUN_NETNS_HOST_IP="10.200.0.1"
+JAILRUN_NETNS_NAME="agentns"
+JAILRUN_NETNS_VETH_HOST="veth-host"
+JAILRUN_NETNS_VETH_AGENT="veth-agent"
+JAILRUN_PROXY_PORT_RANGE_START="abc"
+JAILRUN_PROXY_PORT_RANGE_END="60099"
+EOC
+
+  PATH="$shim_bin:$PATH" run "$fixture/wsl2-netns-setup.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"JAILRUN_PROXY_PORT_RANGE_START / _END must be integers in 1..65535"* ]]
+
+  # Leading-zero rejection (decimal integer contract — no leading zeros).
+  cat >"$fixture_lib/netns-const.sh" <<'EOC'
+JAILRUN_NETNS_HOST_IP="10.200.0.1"
+JAILRUN_NETNS_NAME="agentns"
+JAILRUN_NETNS_VETH_HOST="veth-host"
+JAILRUN_NETNS_VETH_AGENT="veth-agent"
+JAILRUN_PROXY_PORT_RANGE_START="0001"
+JAILRUN_PROXY_PORT_RANGE_END="60099"
+EOC
+  PATH="$shim_bin:$PATH" run "$fixture/wsl2-netns-setup.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must be integers in 1..65535"* ]]
+}
+
+# --- B1: setup applies OUTPUT --dport range inside the namespace ---
+
+@test "setup applies OUTPUT --dport range inside the namespace" {
+  _netns_gate_or_skip
+  run "$_setup"
+  [ "$status" -eq 0 ]
+  run ip netns exec "$_ns" iptables -S OUTPUT
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-P OUTPUT DROP"* ]]
+  [[ "$output" == *"-A OUTPUT -o lo -j ACCEPT"* ]]
+  [[ "$output" == *"--dport ${_range_start}:${_range_end}"* ]]
+  [[ "$output" == *"-d ${_host_ip}"* ]]
+  "$_teardown"
+}
+
+# --- B2: a destination port outside the range is dropped (triangulated
+# with B1 + B3 per the design "決定性の根拠" section) ---
+
+@test "namespace egress to a port outside the SoT range is dropped" {
+  _netns_gate_or_skip
+  if [ "$_range_start" -le 8080 ] && [ 8080 -le "$_range_end" ]; then
+    skip "port 8080 falls inside the configured SoT range, cannot probe deny path"
+  fi
+  run "$_setup"
+  [ "$status" -eq 0 ]
+  _start_host_listener 8080
+  # OUTPUT DROP swallows the SYN, so the in-namespace connect times out
+  # rather than being refused fast. status=124 is the GNU `timeout` rc.
+  run ip netns exec "$_ns" timeout 3 bash -c 'exec 3<>/dev/tcp/'"$_host_ip"'/8080'
+  [ "$status" -eq 124 ]
+  "$_teardown"
+}
+
+# --- B3: a destination port inside the range is accepted (proves the
+# listener / route are healthy, ruling out B2 false-positives) ---
+
+@test "namespace egress to a port inside the SoT range is accepted" {
+  _netns_gate_or_skip
+  local in_port="$_range_start"
+  run "$_setup"
+  [ "$status" -eq 0 ]
+  _start_host_listener "$in_port"
+  run ip netns exec "$_ns" timeout 3 bash -c "exec 3<>/dev/tcp/$_host_ip/$in_port"
+  [ "$status" -eq 0 ]
+  "$_teardown"
+}
+
+# --- B4: re-setup is idempotent for the OUTPUT --dport ACCEPT row ---
+
+@test "re-setup is idempotent for the OUTPUT --dport ACCEPT row" {
+  _netns_gate_or_skip
+  run "$_setup"
+  [ "$status" -eq 0 ]
+  run "$_setup"
+  [ "$status" -eq 0 ]
+  run ip netns exec "$_ns" iptables -S OUTPUT
+  [ "$status" -eq 0 ]
+  # Exactly one --dport ACCEPT row, regardless of how many times setup ran.
+  local count
+  count=$(printf '%s\n' "$output" | grep -cE -- "--dport ${_range_start}:${_range_end}.*-j ACCEPT" || true)
+  [ "$count" -eq 1 ]
+  "$_teardown"
+}


### PR DESCRIPTION
## 概要

Issue #86 で defer された「WSL2 namespace 内 OUTPUT iptables ルールが宛先 host IP のみで宛先ポートを限定していない」defense-in-depth gap を解消する patch リリース（v0.4.1）。

ポート範囲 SoT (`JAILRUN_PROXY_PORT_RANGE_START`/`_END`) を `lib/netns-const.sh` に追加し、setup スクリプトの OUTPUT を `--dport START:END` に限定。`lib/proxy.py` の bind 経路を SoT 範囲内に閉じ込め、Python loader (`lib/netns_const_loader.py`) を新設して setup / proxy 双方が同じ SoT を消費する単一窓口を提供。N=10 並列 × 5 反復の可用性テストで範囲幅 60000-60099 を確定。「実行時 sudo 不要」「setup 一回」という v0.4.0 設計特性は維持。

## サイクル成果物

| Unit | 内容 | コミット |
|------|------|---------|
| 001 | ポート範囲 SoT 定義 + setup スクリプト OUTPUT ルール限定 + bats 11 件 | 526a4a6 |
| 002 | proxy bind の範囲内限定 + Python loader 新設 + N=10×5 並列可用性テスト + Python unit 5 件 + bats 14 件 | f10527a |
| 003 | README / HISTORY / コードコメント整合 + VERSION bump 0.4.0 → 0.4.1 | bfabb49 |

## レビューサマリ

各 Unit の AI レビュー履歴は以下参照（review summary は `.aidlc/cycles/v0.4.1/construction/units/` に格納、`.gitignore` 対象のため未公開）。

| Unit | 計画 | 設計 | コード | 統合 | 合計指摘 / Resolved |
|------|------|------|-------|------|---------------------|
| 001 | 3R | 3R | 2R | 2R | 7 / 7 |
| 002 | 2R | 3R | 2R | 1R | 12 / 12 |
| 003 | 3R | — | 2R | 1R | 7 / 7 |
| 合計 | — | — | — | — | **26 / 26 全 resolved** |

主な修正反映:

- 整数検証の先頭ゼロ拒否強化（Unit 001 コードレビュー R1）
- Unit 002 consumption contract の明示固定（Unit 001 計画 R1）
- `sh -c` injection 排除（Unit 002 コードレビュー R1）
- runtime SoT 上書き経路撤廃（`JAILRUN_LIB` 環境変数依存削除、Unit 002 コードレビュー R1）
- README の SoT 変更時挙動説明を実装と整合（「proxy 起動失敗」→「runtime fail-closed = 起動はするが到達不可」、Unit 003 コードレビュー R1）

## テスト結果

`make test` 全 348 件 pass / 0 fail / 16 skip（root + iproute2 + iptables 必須の動作テストが unprivileged 環境で skip）。

| 区分 | 件数 | 内容 |
|------|------|------|
| bats | 268 | 既存 + 新規（`wsl2_netns_output_range.bats` 11 件 / `proxy_port_range.bats` 3 件 / `proxy_parallel_availability.bats` 1 件 / S7 共通テストベクトル拡張） |
| Python unittest | 80 | 既存 75 件 + 新規 5 件（`test_netns_const_loader.py` / `test_proxy.py` の `TestBindInRange` + `TestRunProxyPortRange`） |
| Skipped | 16 | root-gated WSL2 netns 動作テスト |

## 既存ユーザーへの影響と移行手順

v0.4.0 で `agentns` を setup 済みのユーザーは、新しい OUTPUT ポート範囲限定ルールを反映するために手動で再 setup が必要。README に確認コマンドと再 setup 手順を明記:

```bash
sudo ip netns exec agentns iptables -L OUTPUT -v -n | grep dpts
# expected: ... dpts:60000:60099 ... ACCEPT

# 旧形式（dpts なし）の場合は再 setup:
sudo scripts/wsl2-netns-teardown.sh
sudo scripts/wsl2-netns-setup.sh
```

## マージ後のチェック項目

- [ ] `v0.4.1` タグ作成・push
- [ ] Milestone v0.4.1 (#6) クローズ
- [ ] Issue #86 自動クローズ（Closes 経由）

Closes #86
