### PR TITLE
chore: AI-DLC を v2.6.3 にアップグレード

### DIFF
--- a/.aidlc/config.toml
+++ b/.aidlc/config.toml
@@ -1,7 +1,7 @@
 # AI-DLC プロジェクト設定
 # 生成日: 2026-03-28
 
-starter_kit_version = "2.5.1"
+starter_kit_version = "2.6.3"
 
 [project]
 name = "jailrun"
@@ -89,6 +89,7 @@ command = "npx markdownlint-cli2"
 # - false: フィードバック送信機能を無効化（企業利用時のセキュリティ対策）
 enabled = true
 upstream_repo = "ikeisuke/ai-dlc-starter-kit"
+open_in_browser = false
 
 [rules.automation]
 # 自動化設定（v1.18.0で追加）


### PR DESCRIPTION
## Summary

- AI-DLC Starter Kit を v2.5.1 -> v2.6.3 にアップグレード
- starter_kit_version を更新
- defaults.toml 同期: rules.feedback.open_in_browser=false を追記

## Background

/aidlc:aidlc-setup のアップグレードモード経路で生成。

- migrate-config: 適用変更なし（既存スキーマと整合）
- detect-missing-keys: 1 件追加 (rules.feedback.open_in_browser=false)
- starter_kit_version: 2.5.1 -> 2.6.3
- AI ツール設定 (.claude/settings.json): 既存と一致のためスキップ

## Test plan

- [ ] スターターキットがプロジェクト設定として v2.6.3 を参照することを確認
- [ ] 後続の /aidlc inception 実行が問題なく進むことを確認